### PR TITLE
Adjust module resolution order in webpack configuration

### DIFF
--- a/apps/electron/webpack.main.config.ts
+++ b/apps/electron/webpack.main.config.ts
@@ -17,7 +17,7 @@ export const mainConfig: Configuration = {
   plugins,
   resolve: {
     extensions: [".js", ".ts", ".jsx", ".tsx", ".css", ".json"],
-    modules: [path.resolve(__dirname, "../../node_modules"), "node_modules"],
+    modules: ["node_modules", path.resolve(__dirname, "../../node_modules")],
     alias: {
       "@": path.resolve(__dirname, "src"),
       "@mcp-router/shared": path.resolve(


### PR DESCRIPTION
Modify the module resolution order in the webpack configuration to fix execa error.