### PR TITLE
fix(mcp-server-manager): resolve the issue where server enabled statu…

### DIFF
--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,3 @@
+
+# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
+.specstory/**

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ yarn.lock
 .kiro
 .vscode
 .serena
+.specstory

--- a/apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts
+++ b/apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts
@@ -46,8 +46,8 @@ export function setupMcpServerHandlers(
 
       // For remote servers, test the connection
       if (serverConfig.serverType !== "local") {
-        await mcpServerManager.startServer(server.id);
-        mcpServerManager.stopServer(server.id);
+        await mcpServerManager.startServer(server.id, undefined, false);
+        mcpServerManager.stopServer(server.id, undefined, false);
       }
 
       return server;


### PR DESCRIPTION
resolve the issue where server enabled status is lost after restart

- Add persist parameter to startServer and stopServer methods
- Automatically update autoStart status when users manually start/stop the server
- Do not modify user configurations when the application exits or starts automatically
- Fix the problem that autoStart is reset to false after computer restart"
