### PR TITLE
fix(electron): handle EPIPE errors on console output (Linux)

### DIFF
--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -1,3 +1,7 @@
+// Patch console methods FIRST to prevent EPIPE errors during shutdown
+import { patchConsoleForEpipe } from "@/main/utils/logger";
+patchConsoleForEpipe();
+
 import { app, BrowserWindow, session, shell, nativeTheme } from "electron";
 import path from "node:path";
 import { MCPServerManager } from "@/main/modules/mcp-server-manager/mcp-server-manager";

--- a/apps/electron/src/main/utils/logger.ts
+++ b/apps/electron/src/main/utils/logger.ts
@@ -5,6 +5,42 @@
 import { isDevelopment } from "./environment";
 
 /**
+ * Wraps a console method to safely handle EPIPE errors.
+ * EPIPE occurs when stdout/stderr is closed (e.g., during app shutdown)
+ * and the app tries to write to it.
+ */
+function safeConsoleWrapper<T extends (...args: any[]) => void>(
+  originalMethod: T,
+): T {
+  return ((...args: any[]) => {
+    try {
+      originalMethod.apply(console, args);
+    } catch (error: any) {
+      // Silently ignore EPIPE errors - they occur when the output stream is closed
+      if (error?.code !== "EPIPE") {
+        // Re-throw non-EPIPE errors
+        throw error;
+      }
+    }
+  }) as T;
+}
+
+/**
+ * Patches global console methods to handle EPIPE errors gracefully.
+ * This prevents the app from crashing with infinite error dialogs
+ * when stdout/stderr is closed during shutdown.
+ *
+ * Should be called as early as possible in the app lifecycle.
+ */
+export function patchConsoleForEpipe(): void {
+  console.log = safeConsoleWrapper(console.log);
+  console.error = safeConsoleWrapper(console.error);
+  console.warn = safeConsoleWrapper(console.warn);
+  console.info = safeConsoleWrapper(console.info);
+  console.debug = safeConsoleWrapper(console.debug);
+}
+
+/**
  * INFO レベルのログを出力
  * @param args ログに出力する任意の引数
  */


### PR DESCRIPTION
## Summary
- Fix infinite error dialog popups caused by EPIPE errors on Linux during app shutdown

## Problem
On Linux (observed on Ubuntu with KDE Plasma/Wayland), when the Electron app is shutting down or the stdout/stderr pipe is closed, `console.log`/`error`/`warn` calls throw `EPIPE` errors. This causes infinite JavaScript error dialog popups that require force-killing the application.

The error manifests as:
```
Uncaught Exception:
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    ...
    at getSqliteManager (apps/electron/.webpack/main/index.js:111652:13)
```

## Solution
Patch global console methods at the very start of app initialization to catch and silently ignore `EPIPE` errors while preserving normal error handling for all other error types.

## Changes
- Added `patchConsoleForEpipe()` function in `apps/electron/src/main/utils/logger.ts`
- Call the patch at the first line of `apps/electron/src/main.ts` before any other imports

## Test plan
- [x] Verified app compiles successfully with webpack
- [ ] Test on Linux: start app, close it, verify no error dialogs appear
- [ ] Test on macOS/Windows: verify no regression in normal logging behavior