### PR TITLE
feat(tool-catalog): implement tool catalog with BM25F search and project optimization

### DIFF
--- a/apps/electron/src/global.d.ts
+++ b/apps/electron/src/global.d.ts
@@ -8,6 +8,7 @@ import type {
   MCPTool,
   MCPServer,
   Project,
+  ProjectOptimization,
   TokenServerAccess,
 } from "@mcp_router/shared";
 import {
@@ -153,7 +154,10 @@ declare global {
       createProject: (input: { name: string }) => Promise<Project>;
       updateProject: (
         id: string,
-        updates: { name?: string },
+        updates: {
+          name?: string;
+          optimization?: ProjectOptimization;
+        },
       ) => Promise<Project>;
       deleteProject: (id: string) => Promise<void>;
 

--- a/apps/electron/src/locales/en.json
+++ b/apps/electron/src/locales/en.json
@@ -11,6 +11,7 @@
     "loading": "Loading...",
     "close": "Close",
     "remove": "Remove",
+    "removing": "Removing...",
     "search": "Search",
     "update": "Update",
     "send": "Send"
@@ -100,6 +101,8 @@
     "accountAndPlan": "Account & Plan",
     "proFeatures": "Pro Features",
     "preferences": "Preferences",
+    "authentication": "Authentication",
+    "appearance": "Appearance",
     "theme": "Theme",
     "themeLight": "Light",
     "themeDark": "Dark",
@@ -109,8 +112,22 @@
     "loggingIn": "Logging in...",
     "logout": "Logout",
     "loggingOut": "Logging out...",
+    "loggedInAs": "Logged in as",
+    "subscription": "Subscription",
+    "subscriptionDescription": "View your current plan and subscription status.",
+    "subscriptionStatusValue": {
+      "active": "Active",
+      "canceled": "Canceled",
+      "incomplete": "Incomplete",
+      "trialing": "Trialing",
+      "past_due": "Past due"
+    },
+    "planName": "Plan",
     "planNameUnknown": "Not set",
+    "notSubscribed": "Not subscribed",
     "getPro": "Get Pro",
+    "refreshSubscription": "Refresh",
+    "refreshingSubscription": "Refreshing...",
     "cloudSync": "Cloud Sync",
     "cloudSyncDescription": "Sync your workspaces and servers across devices with end-to-end encryption.",
     "proOnly": "Pro only",
@@ -161,6 +178,7 @@
     "deleteFailed": "Failed to delete app"
   },
   "serverDetails": {
+    "settings": "Settings",
     "serverName": "Server Name",
     "finalCommand": "Execution Command",
     "noInputParams": "No input parameters",
@@ -212,7 +230,10 @@
     "creating": "Creating...",
     "projectSettings": "Project Settings",
     "projectSettingsDescription": "Projects let you isolate the contexts where MCP servers are used.",
-    "projectSettingsCliHint": "To use the servers assigned to a project, run a command like: npx -y @mcp_router/cli connect --project <project-name>."
+    "projectSettingsCliHint": "To use the servers assigned to a project, run a command like: npx -y @mcp_router/cli connect --project <project-name>.",
+    "contextOptimization": "Context Optimization",
+    "searchStrategyBm25": "BM25",
+    "searchStrategyCloud": "Advanced"
   },
   "serverSettings": {
     "title": "{{serverName}} Settings",

--- a/apps/electron/src/locales/ja.json
+++ b/apps/electron/src/locales/ja.json
@@ -14,6 +14,7 @@
     "loading": "読み込み中...",
     "close": "閉じる",
     "remove": "削除",
+    "removing": "削除中...",
     "search": "検索",
     "update": "アップデート",
     "send": "送信"
@@ -99,6 +100,8 @@
     "accountAndPlan": "アカウントとプラン",
     "proFeatures": "Pro機能",
     "preferences": "設定",
+    "authentication": "認証",
+    "appearance": "外観",
     "theme": "テーマ",
     "themeLight": "ライト",
     "themeDark": "ダーク",
@@ -108,8 +111,22 @@
     "loggingIn": "ログイン中...",
     "logout": "ログアウト",
     "loggingOut": "ログアウト中...",
+    "loggedInAs": "ログイン中のアカウント",
+    "subscription": "サブスクリプション",
+    "subscriptionDescription": "現在のプランとステータスを確認できます。",
+    "subscriptionStatusValue": {
+      "active": "有効",
+      "canceled": "解約済み",
+      "incomplete": "未完了",
+      "trialing": "トライアル中",
+      "past_due": "支払い遅延"
+    },
+    "planName": "プラン",
     "planNameUnknown": "未設定",
+    "notSubscribed": "未契約",
     "getPro": "Proを購入",
+    "refreshSubscription": "更新",
+    "refreshingSubscription": "更新中...",
     "cloudSync": "クラウド同期",
     "cloudSyncDescription": "エンドツーエンド暗号化でワークスペースとサーバーをデバイス間で同期します。",
     "proOnly": "Pro限定",
@@ -160,6 +177,7 @@
     "deleteFailed": "カスタムアプリの削除に失敗しました"
   },
   "serverDetails": {
+    "settings": "設定",
     "serverName": "サーバー名",
     "finalCommand": "実行コマンド",
     "noInputParams": "入力パラメータがありません",
@@ -211,7 +229,10 @@
     "creating": "作成中...",
     "projectSettings": "プロジェクト設定",
     "projectSettingsDescription": "プロジェクトでは、MCPサーバーを利用するコンテキストを分離できます。",
-    "projectSettingsCliHint": "プロジェクトに割り当てたサーバーを利用するには、npx -y @mcp_router/cli connect --project <project-name> のように指定します。"
+    "projectSettingsCliHint": "プロジェクトに割り当てたサーバーを利用するには、npx -y @mcp_router/cli connect --project <project-name> のように指定します。",
+    "contextOptimization": "コンテキスト最適化",
+    "searchStrategyBm25": "BM25",
+    "searchStrategyCloud": "Advanced"
   },
   "serverSettings": {
     "title": "{{serverName}} 設定",

--- a/apps/electron/src/locales/zh.json
+++ b/apps/electron/src/locales/zh.json
@@ -11,6 +11,7 @@
     "loading": "加载中...",
     "close": "关闭",
     "remove": "移除",
+    "removing": "移除中...",
     "search": "搜索",
     "update": "更新",
     "send": "发送"
@@ -100,6 +101,8 @@
     "accountAndPlan": "账户与套餐",
     "proFeatures": "Pro 功能",
     "preferences": "偏好设置",
+    "authentication": "身份验证",
+    "appearance": "外观",
     "theme": "主题",
     "themeLight": "浅色",
     "themeDark": "深色",
@@ -109,8 +112,22 @@
     "loggingIn": "登录中...",
     "logout": "登出",
     "loggingOut": "登出中...",
+    "loggedInAs": "已登录为",
+    "subscription": "订阅",
+    "subscriptionDescription": "查看当前套餐和订阅状态。",
+    "subscriptionStatusValue": {
+      "active": "已激活",
+      "canceled": "已取消",
+      "incomplete": "未完成",
+      "trialing": "试用中",
+      "past_due": "逾期"
+    },
+    "planName": "套餐",
     "planNameUnknown": "未设置",
+    "notSubscribed": "未订阅",
     "getPro": "获取 Pro",
+    "refreshSubscription": "刷新",
+    "refreshingSubscription": "正在刷新...",
     "cloudSync": "云同步",
     "cloudSyncDescription": "通过端到端加密在设备间同步您的工作空间和服务器。",
     "proOnly": "仅限 Pro",
@@ -161,6 +178,7 @@
     "deleteFailed": "应用删除失败"
   },
   "serverDetails": {
+    "settings": "设置",
     "serverName": "服务器名称",
     "finalCommand": "执行命令",
     "noInputParams": "无输入参数",
@@ -212,7 +230,10 @@
     "creating": "正在创建...",
     "projectSettings": "项目设置",
     "projectSettingsDescription": "项目可以将使用 MCP 服务器的上下文隔离开来。",
-    "projectSettingsCliHint": "要使用分配给项目的服务器，请像这样执行命令：npx -y @mcp_router/cli connect --project <project-name>。"
+    "projectSettingsCliHint": "要使用分配给项目的服务器，请像这样执行命令：npx -y @mcp_router/cli connect --project <project-name>。",
+    "contextOptimization": "上下文优化",
+    "searchStrategyBm25": "BM25",
+    "searchStrategyCloud": "Advanced"
   },
   "serverSettings": {
     "title": "{{serverName}} 设置",

--- a/apps/electron/src/main/infrastructure/database/main-database-migration.ts
+++ b/apps/electron/src/main/infrastructure/database/main-database-migration.ts
@@ -104,6 +104,13 @@ export class MainDatabaseMigration {
       description: "Add hooks table for MCP request/response hooks",
       execute: (db) => this.migrateAddHooksTable(db),
     });
+
+    // Projects optimization カラムを追加
+    this.migrations.push({
+      id: "20260120_add_project_optimization_column",
+      description: "Add optimization column to projects table",
+      execute: (db) => this.migrateAddProjectOptimizationColumn(db),
+    });
   }
 
   /**
@@ -603,6 +610,37 @@ export class MainDatabaseMigration {
       }
     } catch (error) {
       console.error("Error while ensuring servers.project_id:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * projects.optimization 列を追加するマイグレーション
+   */
+  private migrateAddProjectOptimizationColumn(db: SqliteManager): void {
+    try {
+      const tableExists = db.get(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name = 'projects'",
+        {},
+      );
+
+      if (!tableExists) {
+        console.log("projects table does not exist, skipping this migration");
+        return;
+      }
+
+      const tableInfo = db.all("PRAGMA table_info(projects)");
+      const columnNames = tableInfo.map((col: any) => col.name);
+
+      if (!columnNames.includes("optimization")) {
+        console.log("Adding optimization column to projects");
+        db.execute("ALTER TABLE projects ADD COLUMN optimization TEXT");
+        console.log("optimization column added");
+      } else {
+        console.log("optimization column already exists, skipping");
+      }
+    } catch (error) {
+      console.error("Error while adding optimization column:", error);
       throw error;
     }
   }

--- a/apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts
+++ b/apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts
@@ -12,6 +12,7 @@ import {
 import { RequestHandlers } from "./request-handlers";
 import { MCPServerManager } from "../mcp-server-manager/mcp-server-manager";
 import { getLogService } from "@/main/modules/mcp-logger/mcp-logger.service";
+import type { ToolCatalogService } from "@/main/modules/tool-catalog/tool-catalog.service";
 
 /**
  * MCP Aggregator Server that combines multiple MCP servers into one
@@ -21,8 +22,14 @@ export class AggregatorServer {
   private transport!: StreamableHTTPServerTransport;
   private requestHandlers: RequestHandlers;
 
-  constructor(serverManager: MCPServerManager) {
-    this.requestHandlers = new RequestHandlers(serverManager);
+  constructor(
+    serverManager: MCPServerManager,
+    toolCatalogService?: ToolCatalogService,
+  ) {
+    this.requestHandlers = new RequestHandlers(
+      serverManager,
+      toolCatalogService,
+    );
     this.initAggregatorServer();
   }
 

--- a/apps/electron/src/main/modules/projects/projects.ipc.ts
+++ b/apps/electron/src/main/modules/projects/projects.ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from "electron";
 import { ProjectService, getProjectService } from "./projects.service";
 import type { MCPServerManager } from "@/main/modules/mcp-server-manager/mcp-server-manager";
+import type { ProjectOptimization } from "@mcp_router/shared";
 
 export function setupProjectHandlers(deps: {
   getServerManager: () => MCPServerManager;
@@ -24,11 +25,16 @@ export function setupProjectHandlers(deps: {
 
   ipcMain.handle(
     "project:update",
-    async (_evt, id: string, updates: { name?: string }) => {
+    async (
+      _evt,
+      id: string,
+      updates: {
+        name?: string;
+        optimization?: ProjectOptimization;
+      },
+    ) => {
       if (!id) throw new Error("Missing project id");
-      const payload: { name?: string } = {};
-      if (updates?.name !== undefined) payload.name = updates.name;
-      return service.update(id, payload);
+      return service.update(id, updates);
     },
   );
 

--- a/apps/electron/src/main/modules/projects/projects.repository.ts
+++ b/apps/electron/src/main/modules/projects/projects.repository.ts
@@ -32,7 +32,8 @@ export class ProjectRepository extends BaseRepository<Project> {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        optimization TEXT
       )
     `);
     this.db.execute(
@@ -46,6 +47,7 @@ export class ProjectRepository extends BaseRepository<Project> {
       name: row.name,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      optimization: row.optimization ?? null,
     };
   }
 
@@ -56,6 +58,7 @@ export class ProjectRepository extends BaseRepository<Project> {
       name: entity.name,
       created_at: entity.createdAt ?? now,
       updated_at: now,
+      optimization: entity.optimization ?? null,
     };
   }
 

--- a/apps/electron/src/main/modules/projects/projects.service.ts
+++ b/apps/electron/src/main/modules/projects/projects.service.ts
@@ -1,6 +1,6 @@
 import { SingletonService } from "@/main/modules/singleton-service";
 import { ProjectRepository } from "./projects.repository";
-import type { Project } from "@mcp_router/shared";
+import type { Project, ProjectOptimization } from "@mcp_router/shared";
 import type { MCPServerManager } from "@/main/modules/mcp-server-manager/mcp-server-manager";
 import { McpServerManagerRepository } from "../mcp-server-manager/mcp-server-manager.repository";
 
@@ -53,6 +53,20 @@ export class ProjectService extends SingletonService<
     }
   }
 
+  getOptimization(projectId: string): ProjectOptimization | undefined {
+    try {
+      const repo = ProjectRepository.getInstance();
+      const project = repo.getById(projectId);
+      return project?.optimization;
+    } catch (error) {
+      console.error(
+        "[ProjectService] Failed to get project optimization:",
+        error,
+      );
+      return undefined;
+    }
+  }
+
   list(): Project[] {
     try {
       return ProjectRepository.getInstance().getAll({ orderBy: "name" });
@@ -82,7 +96,10 @@ export class ProjectService extends SingletonService<
     }
   }
 
-  update(id: string, updates: Partial<Pick<Project, "name">>): Project {
+  update(
+    id: string,
+    updates: Partial<Pick<Project, "name" | "optimization">>,
+  ): Project {
     try {
       const repo = ProjectRepository.getInstance();
       const existing = repo.getById(id);

--- a/apps/electron/src/main/modules/tool-catalog/bm25-search-provider.ts
+++ b/apps/electron/src/main/modules/tool-catalog/bm25-search-provider.ts
@@ -1,0 +1,351 @@
+import type { ToolInfo, SearchResult } from "@mcp_router/shared";
+import type {
+  SearchProvider,
+  SearchProviderRequest,
+} from "./tool-catalog.service";
+
+// BM25 parameters
+const BM25_K1 = 1.5; // Term frequency saturation parameter (typically 1.2-2.0)
+const BM25_B = 0.75; // Document length normalization parameter (typically 0.75)
+
+// BM25F field weights
+const WEIGHT_NAME = 3.0; // Tool name match → high score
+const WEIGHT_DESC = 1.5; // Description match → medium score
+const WEIGHT_PARAMS = 0.5; // Parameter match → low score
+
+// Stop words for tokenization
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "have",
+  "has",
+  "had",
+  "do",
+  "does",
+  "did",
+  "will",
+  "would",
+  "could",
+  "should",
+  "may",
+  "might",
+  "must",
+  "shall",
+  "can",
+  "need",
+  "dare",
+  "ought",
+  "used",
+  "to",
+  "of",
+  "in",
+  "for",
+  "on",
+  "with",
+  "at",
+  "by",
+  "from",
+  "as",
+  "into",
+  "through",
+  "during",
+  "before",
+  "after",
+  "above",
+  "below",
+  "between",
+  "under",
+  "again",
+  "further",
+  "then",
+  "once",
+  "and",
+  "but",
+  "or",
+  "nor",
+  "so",
+  "yet",
+  "both",
+  "either",
+  "neither",
+  "not",
+  "only",
+  "own",
+  "same",
+  "than",
+  "too",
+  "very",
+  "just",
+  "also",
+  "now",
+  "here",
+  "there",
+  "when",
+  "where",
+  "why",
+  "how",
+  "all",
+  "each",
+  "every",
+  "any",
+  "some",
+  "no",
+  "other",
+  "such",
+  "this",
+  "that",
+  "these",
+  "those",
+  "it",
+  "its",
+]);
+
+/**
+ * Tokenizes text into lowercase terms, filtering out short tokens and stop words.
+ */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s\-_.,;:!?()[\]{}'"]+/)
+    .filter((token) => token.length >= 2 && !STOP_WORDS.has(token));
+}
+
+/**
+ * Extracts parameter descriptions from inputSchema.
+ */
+function extractParamDescriptions(tool: ToolInfo): string {
+  const props = tool.inputSchema?.properties;
+  if (!props) {
+    return "";
+  }
+  const descriptions: string[] = [];
+  for (const [name, prop] of Object.entries(props)) {
+    descriptions.push(name);
+    if (prop.description) {
+      descriptions.push(prop.description);
+    }
+  }
+  return descriptions.join(" ");
+}
+
+/**
+ * Represents a tokenized document for BM25F scoring.
+ */
+type TokenizedDoc = {
+  tool: ToolInfo;
+  nameTokens: string[];
+  descTokens: string[];
+  paramTokens: string[];
+};
+
+/**
+ * Corpus statistics for a specific field.
+ */
+type FieldStats = {
+  documentFrequency: Map<string, number>;
+  averageLength: number;
+};
+
+/**
+ * BM25F search provider implementation.
+ * Uses BM25F algorithm with field-specific weights for relevance scoring.
+ */
+export class BM25SearchProvider implements SearchProvider {
+  /**
+   * Search for tools matching the query using BM25F algorithm.
+   */
+  public async search(request: SearchProviderRequest): Promise<SearchResult[]> {
+    const { query, tools, maxResults = 20 } = request;
+
+    const queryTokens = tokenize(query.join(" "));
+    if (queryTokens.length === 0) {
+      return [];
+    }
+
+    // Tokenize all documents by field
+    const docs: TokenizedDoc[] = tools.map((tool) => ({
+      tool,
+      nameTokens: tokenize(`${tool.toolName} ${tool.serverName}`),
+      descTokens: tokenize(tool.description || ""),
+      paramTokens: tokenize(extractParamDescriptions(tool)),
+    }));
+
+    // Calculate corpus statistics per field
+    const nameStats = this.calculateFieldStats(docs, "nameTokens");
+    const descStats = this.calculateFieldStats(docs, "descTokens");
+    const paramStats = this.calculateFieldStats(docs, "paramTokens");
+    const totalDocuments = docs.length;
+
+    // Score each document using BM25F
+    const scoredResults: Array<{
+      tool: ToolInfo;
+      score: number;
+    }> = [];
+
+    for (const doc of docs) {
+      const score = this.calculateBM25FScore(
+        doc,
+        queryTokens,
+        nameStats,
+        descStats,
+        paramStats,
+        totalDocuments,
+      );
+
+      if (score > 0) {
+        scoredResults.push({
+          tool: doc.tool,
+          score,
+        });
+      }
+    }
+
+    // Sort by score descending
+    scoredResults.sort((a, b) => b.score - a.score);
+
+    // Normalize scores to 0-1 range
+    const maxScore = scoredResults.length > 0 ? scoredResults[0].score : 1;
+    const results: SearchResult[] = scoredResults
+      .slice(0, maxResults)
+      .map(({ tool, score }) => ({
+        toolName: tool.toolName,
+        serverId: tool.serverId,
+        serverName: tool.serverName,
+        projectId: tool.projectId,
+        description: tool.description,
+        relevance: maxScore > 0 ? score / maxScore : 0,
+      }));
+
+    return results;
+  }
+
+  /**
+   * Calculates corpus statistics for a specific field.
+   */
+  private calculateFieldStats(
+    docs: TokenizedDoc[],
+    field: "nameTokens" | "descTokens" | "paramTokens",
+  ): FieldStats {
+    const documentFrequency = new Map<string, number>();
+    let totalLength = 0;
+
+    for (const doc of docs) {
+      const tokens = doc[field];
+      totalLength += tokens.length;
+
+      // Count document frequency for each unique term
+      const uniqueTerms = new Set(tokens);
+      for (const term of uniqueTerms) {
+        documentFrequency.set(term, (documentFrequency.get(term) || 0) + 1);
+      }
+    }
+
+    const averageLength = docs.length > 0 ? totalLength / docs.length : 0;
+
+    return { documentFrequency, averageLength };
+  }
+
+  /**
+   * Calculates IDF (Inverse Document Frequency) for a term.
+   * Uses BM25 IDF formula: log((N - n + 0.5) / (n + 0.5) + 1)
+   */
+  private calculateIDF(
+    term: string,
+    documentFrequency: Map<string, number>,
+    totalDocuments: number,
+  ): number {
+    const n = documentFrequency.get(term) || 0;
+    const N = totalDocuments;
+    return Math.log((N - n + 0.5) / (n + 0.5) + 1);
+  }
+
+  /**
+   * Calculates BM25 score for a single field.
+   */
+  private calculateFieldScore(
+    tokens: string[],
+    queryTokens: string[],
+    stats: FieldStats,
+    totalDocuments: number,
+  ): number {
+    if (tokens.length === 0) {
+      return 0;
+    }
+
+    const termFrequency = new Map<string, number>();
+    for (const token of tokens) {
+      termFrequency.set(token, (termFrequency.get(token) || 0) + 1);
+    }
+
+    let score = 0;
+    const docLength = tokens.length;
+
+    for (const queryTerm of queryTokens) {
+      const tf = termFrequency.get(queryTerm) || 0;
+      if (tf === 0) {
+        continue;
+      }
+
+      const idf = this.calculateIDF(
+        queryTerm,
+        stats.documentFrequency,
+        totalDocuments,
+      );
+      const lengthNormalization =
+        stats.averageLength > 0
+          ? 1 - BM25_B + BM25_B * (docLength / stats.averageLength)
+          : 1;
+      const tfComponent =
+        (tf * (BM25_K1 + 1)) / (tf + BM25_K1 * lengthNormalization);
+
+      score += idf * tfComponent;
+    }
+
+    return score;
+  }
+
+  /**
+   * Calculates BM25F score for a document using field-specific weights.
+   */
+  private calculateBM25FScore(
+    doc: TokenizedDoc,
+    queryTokens: string[],
+    nameStats: FieldStats,
+    descStats: FieldStats,
+    paramStats: FieldStats,
+    totalDocuments: number,
+  ): number {
+    const nameScore = this.calculateFieldScore(
+      doc.nameTokens,
+      queryTokens,
+      nameStats,
+      totalDocuments,
+    );
+    const descScore = this.calculateFieldScore(
+      doc.descTokens,
+      queryTokens,
+      descStats,
+      totalDocuments,
+    );
+    const paramScore = this.calculateFieldScore(
+      doc.paramTokens,
+      queryTokens,
+      paramStats,
+      totalDocuments,
+    );
+
+    return (
+      WEIGHT_NAME * nameScore +
+      WEIGHT_DESC * descScore +
+      WEIGHT_PARAMS * paramScore
+    );
+  }
+}

--- a/apps/electron/src/main/modules/tool-catalog/tool-catalog-handler.ts
+++ b/apps/electron/src/main/modules/tool-catalog/tool-catalog-handler.ts
@@ -1,0 +1,302 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  AGGREGATOR_SERVER_NAME,
+  MCPServer,
+  MCPTool,
+  UNASSIGNED_PROJECT_ID,
+} from "@mcp_router/shared";
+import { TokenValidator } from "@/main/modules/mcp-server-runtime/token-validator";
+import { RequestHandlerBase } from "@/main/modules/mcp-server-runtime/request-handler-base";
+import { getProjectService } from "@/main/modules/projects/projects.service";
+import { ToolCatalogService } from "./tool-catalog.service";
+
+export const META_TOOLS: MCPTool[] = [
+  {
+    name: "tool_discovery",
+    description:
+      "Discover available tools across MCP servers. " +
+      "Call this freely whenever you're unsure what tools exist or want to explore capabilities for your task. " +
+      "It's lightweight and helps you understand your options before taking action.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "array",
+          items: { type: "string" },
+          description: "Keywords describing the functionality you need.",
+        },
+        context: {
+          type: "string",
+          description: "Your current task context to improve relevance.",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum number of results to return.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tool_execute",
+    description:
+      "Execute a discovered tool on an MCP server. " +
+      "Use this after tool_discovery or when you know the exact toolKey.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        toolKey: {
+          type: "string",
+          description:
+            "Tool identifier (serverId:toolName) from tool_search results.",
+        },
+        arguments: {
+          type: "object",
+          description: "Arguments to pass to the tool.",
+        },
+      },
+      required: ["toolKey"],
+    },
+  },
+];
+
+type ToolCatalogHandlerDeps = {
+  servers: Map<string, MCPServer>;
+  clients: Map<string, Client>;
+  serverStatusMap: Map<string, boolean>;
+  toolCatalogService: ToolCatalogService;
+};
+
+/**
+ * Handles tool_discovery and tool_execute meta-tools.
+ */
+export class ToolCatalogHandler extends RequestHandlerBase {
+  private servers: Map<string, MCPServer>;
+  private clients: Map<string, Client>;
+  private serverStatusMap: Map<string, boolean>;
+  private toolCatalogService: ToolCatalogService;
+
+  constructor(tokenValidator: TokenValidator, deps: ToolCatalogHandlerDeps) {
+    super(tokenValidator);
+    this.servers = deps.servers;
+    this.clients = deps.clients;
+    this.serverStatusMap = deps.serverStatusMap;
+    this.toolCatalogService = deps.toolCatalogService;
+  }
+
+  private normalizeProjectId(projectId: unknown): string | null {
+    if (
+      projectId === undefined ||
+      projectId === null ||
+      projectId === "" ||
+      projectId === UNASSIGNED_PROJECT_ID
+    ) {
+      return null;
+    }
+    if (typeof projectId === "string") {
+      return projectId;
+    }
+    return null;
+  }
+
+  private requireValidToken(token?: string): {
+    token: string;
+    clientId: string;
+  } {
+    if (!token || typeof token !== "string") {
+      throw new McpError(ErrorCode.InvalidRequest, "Token is required");
+    }
+
+    const validation = this.tokenValidator.validateToken(token);
+    if (!validation.isValid) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        validation.error || "Invalid token",
+      );
+    }
+
+    return { token, clientId: validation.clientId || "unknownClient" };
+  }
+
+  private parseToolKey(toolKey: string): {
+    serverId: string;
+    toolName: string;
+  } {
+    const separatorIndex = toolKey.indexOf(":");
+    if (separatorIndex <= 0 || separatorIndex >= toolKey.length - 1) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Invalid toolKey format: ${toolKey}`,
+      );
+    }
+
+    return {
+      serverId: toolKey.slice(0, separatorIndex),
+      toolName: toolKey.slice(separatorIndex + 1),
+    };
+  }
+
+  private buildToolKey(serverId: string, toolName: string): string {
+    return `${serverId}:${toolName}`;
+  }
+
+  private getProjectOptimization(projectId: string | null) {
+    if (!projectId) {
+      return undefined;
+    }
+    return getProjectService().getOptimization(projectId);
+  }
+
+  /**
+   * Handle tool_discovery request.
+   */
+  public async handleToolDiscovery(request: any): Promise<any> {
+    const token = request.params._meta?.token as string | undefined;
+    const projectId = this.normalizeProjectId(request.params._meta?.projectId);
+    const { clientId, token: validatedToken } = this.requireValidToken(token);
+
+    const args = request.params.arguments || {};
+    const rawQuery = args.query;
+    const query = Array.isArray(rawQuery)
+      ? rawQuery.filter((q): q is string => typeof q === "string")
+      : [];
+    if (query.length === 0) {
+      throw new McpError(ErrorCode.InvalidRequest, "Query is required");
+    }
+    const context = typeof args.context === "string" ? args.context : undefined;
+    const maxResults =
+      typeof args.maxResults === "number" ? args.maxResults : undefined;
+
+    const optimization = this.getProjectOptimization(projectId);
+
+    return await this.executeWithHooksAndLogging(
+      "tools/discovery",
+      { query, context, maxResults },
+      clientId,
+      AGGREGATOR_SERVER_NAME,
+      "ToolDiscovery",
+      async () => {
+        const allowedServerIds = new Set<string>();
+        for (const serverId of this.servers.keys()) {
+          if (this.tokenValidator.hasServerAccess(validatedToken, serverId)) {
+            allowedServerIds.add(serverId);
+          }
+        }
+
+        const response = await this.toolCatalogService.searchTools(
+          { query, context, maxResults },
+          {
+            projectId,
+            allowedServerIds,
+            toolCatalogEnabled: !!optimization,
+          },
+        );
+
+        const results = response.results.map((result) => ({
+          toolKey: this.buildToolKey(result.serverId, result.toolName),
+          toolName: result.toolName,
+          serverName: result.serverName,
+          description: result.description,
+          relevance: result.relevance,
+          explanation: result.explanation,
+        }));
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(results, null, 2),
+            },
+          ],
+        };
+      },
+    );
+  }
+
+  /**
+   * Handle tool_execute request.
+   */
+  public async handleToolExecute(request: any): Promise<any> {
+    const token = request.params._meta?.token as string | undefined;
+    const projectId = this.normalizeProjectId(request.params._meta?.projectId);
+    const { clientId, token: validatedToken } = this.requireValidToken(token);
+
+    const args = request.params.arguments || {};
+    const toolKey = typeof args.toolKey === "string" ? args.toolKey.trim() : "";
+    if (!toolKey) {
+      throw new McpError(ErrorCode.InvalidRequest, "toolKey is required");
+    }
+
+    const { serverId, toolName } = this.parseToolKey(toolKey);
+    const server = this.servers.get(serverId);
+    if (!server) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Unknown server: ${serverId}`,
+      );
+    }
+
+    const serverName = server.name || serverId;
+
+    if (!this.tokenValidator.hasServerAccess(validatedToken, serverId)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "Token does not have access to this server",
+      );
+    }
+
+    if (!this.toolCatalogService.matchesProject(server, projectId)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "Tool not available for the selected project",
+      );
+    }
+
+    if (server.toolPermissions && server.toolPermissions[toolName] === false) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Tool "${toolName}" is disabled for this server`,
+      );
+    }
+
+    const client = this.clients.get(serverId);
+    if (!client) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Server ${serverName} is not connected`,
+      );
+    }
+
+    if (!this.serverStatusMap.get(serverName)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Server ${serverName} is not running`,
+      );
+    }
+
+    const toolArguments = args.arguments ?? {};
+
+    return await this.executeWithHooksAndLogging(
+      "tools/call",
+      { toolKey, arguments: toolArguments },
+      clientId,
+      serverName,
+      "ToolExecute",
+      async () => {
+        return await client.callTool(
+          {
+            name: toolName,
+            arguments: toolArguments,
+          },
+          undefined,
+          {
+            timeout: 60 * 60 * 1000, // 60 minutes
+            resetTimeoutOnProgress: true,
+          },
+        );
+      },
+      { serverId },
+    );
+  }
+}

--- a/apps/electron/src/main/modules/tool-catalog/tool-catalog.service.ts
+++ b/apps/electron/src/main/modules/tool-catalog/tool-catalog.service.ts
@@ -1,0 +1,163 @@
+import type {
+  SearchRequest,
+  SearchResponse,
+  SearchResult,
+  MCPServer,
+  ToolInfo,
+} from "@mcp_router/shared";
+import type { MCPServerManager } from "@/main/modules/mcp-server-manager/mcp-server-manager";
+import { BM25SearchProvider } from "./bm25-search-provider";
+
+/**
+ * Search request parameters for search providers.
+ */
+export type SearchProviderRequest = {
+  query: string[];
+  context?: string;
+  tools: ToolInfo[];
+  maxResults?: number;
+};
+
+/**
+ * Interface for search providers.
+ */
+export interface SearchProvider {
+  search(request: SearchProviderRequest): Promise<SearchResult[]>;
+}
+
+type SearchContext = {
+  projectId: string | null;
+  allowedServerIds?: Set<string>;
+  toolCatalogEnabled?: boolean;
+};
+
+const DEFAULT_MAX_RESULTS = 20;
+const MAX_RESULTS_LIMIT = 100;
+
+export class ToolCatalogService {
+  private serverManager: MCPServerManager;
+  private searchProvider: SearchProvider;
+
+  constructor(
+    serverManager: MCPServerManager,
+    searchProvider?: SearchProvider,
+  ) {
+    this.serverManager = serverManager;
+    this.searchProvider = searchProvider ?? new BM25SearchProvider();
+  }
+
+  /**
+   * Searches for tools matching the query.
+   * Collects available tools on-demand from running servers.
+   */
+  public async searchTools(
+    request: SearchRequest,
+    context: SearchContext,
+  ): Promise<SearchResponse> {
+    // Check if tool catalog is enabled for this project
+    // Default to enabled if not specified
+    if (context.toolCatalogEnabled === false) {
+      return { results: [] };
+    }
+
+    const query = request.query.filter((q) => q.trim());
+    if (query.length === 0) {
+      return { results: [] };
+    }
+    const maxResults = this.normalizeMaxResults(request.maxResults);
+
+    // Collect available tools on-demand
+    const availableTools = await this.collectAvailableTools(context);
+
+    if (availableTools.length === 0) {
+      return { results: [] };
+    }
+
+    // Use search provider
+    const results = await this.searchProvider.search({
+      query,
+      context: request.context,
+      tools: availableTools,
+      maxResults,
+    });
+
+    return { results };
+  }
+
+  /**
+   * Collects available tools from running servers on-demand.
+   * Applies filtering based on context (projectId, allowedServerIds, toolPermissions).
+   */
+  private async collectAvailableTools(
+    context: SearchContext,
+  ): Promise<ToolInfo[]> {
+    const { servers, clients, serverStatusMap } = this.serverManager.getMaps();
+    const tools: ToolInfo[] = [];
+
+    for (const [serverId, client] of clients.entries()) {
+      const server = servers.get(serverId);
+      if (!server || !client) {
+        continue;
+      }
+
+      const serverName = server.name || serverId;
+      if (!serverStatusMap.get(serverName)) {
+        continue;
+      }
+
+      if (context.allowedServerIds && !context.allowedServerIds.has(serverId)) {
+        continue;
+      }
+
+      if (!this.matchesProject(server, context.projectId)) {
+        continue;
+      }
+
+      const permissions = server.toolPermissions || {};
+
+      try {
+        const toolResponse = await client.listTools();
+        const toolList = toolResponse?.tools ?? [];
+
+        for (const tool of toolList) {
+          if (permissions[tool.name] === false) {
+            continue;
+          }
+
+          tools.push({
+            toolKey: `${serverId}:${tool.name}`,
+            serverId,
+            toolName: tool.name,
+            serverName,
+            projectId: server.projectId ?? null,
+            description: tool.description,
+            inputSchema: tool.inputSchema as ToolInfo["inputSchema"],
+          });
+        }
+      } catch (error) {
+        console.error(
+          `[ToolCatalog] Failed to list tools from ${serverName}:`,
+          error,
+        );
+      }
+    }
+
+    return tools;
+  }
+
+  private normalizeMaxResults(value?: number): number {
+    if (!value || !Number.isFinite(value)) {
+      return DEFAULT_MAX_RESULTS;
+    }
+    const normalized = Math.max(1, Math.floor(value));
+    return Math.min(MAX_RESULTS_LIMIT, normalized);
+  }
+
+  public matchesProject(
+    server: MCPServer | undefined,
+    projectId: string | null,
+  ): boolean {
+    const serverProject = server?.projectId ?? null;
+    return projectId === null || serverProject === projectId;
+  }
+}

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -2,7 +2,11 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 
 import { contextBridge, ipcRenderer } from "electron";
-import type { CreateServerInput, TokenServerAccess } from "@mcp_router/shared";
+import type {
+  CreateServerInput,
+  ProjectOptimization,
+  TokenServerAccess,
+} from "@mcp_router/shared";
 
 // Consolidate everything into one contextBridge call
 
@@ -178,7 +182,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   listProjects: () => ipcRenderer.invoke("project:list"),
   createProject: (input: { name: string }) =>
     ipcRenderer.invoke("project:create", input),
-  updateProject: (id: string, updates: { name?: string }) =>
-    ipcRenderer.invoke("project:update", id, updates),
+  updateProject: (
+    id: string,
+    updates: { name?: string; optimization?: ProjectOptimization },
+  ) => ipcRenderer.invoke("project:update", id, updates),
   deleteProject: (id: string) => ipcRenderer.invoke("project:delete", id),
 });

--- a/apps/electron/src/renderer/components/Home.tsx
+++ b/apps/electron/src/renderer/components/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { MCPServer } from "@mcp_router/shared";
+import { MCPServer, ProjectOptimization } from "@mcp_router/shared";
 import { ScrollArea } from "@mcp_router/ui";
 import { Badge } from "@mcp_router/ui";
 import { Switch } from "@mcp_router/ui";
@@ -230,29 +230,31 @@ const Home: React.FC = () => {
 
   const handleCreateProject = React.useCallback(
     async (input: { name: string }) => {
-      const created = await createProject(input);
-      await listProjects();
-      return created;
+      return await createProject(input);
     },
-    [createProject, listProjects],
+    [createProject],
   );
 
   const handleRenameProject = React.useCallback(
     async (id: string, updates: { name: string }) => {
-      const updated = await updateProjectInStore(id, updates);
-      await listProjects();
-      return updated;
+      return await updateProjectInStore(id, updates);
     },
-    [listProjects, updateProjectInStore],
+    [updateProjectInStore],
   );
 
   const handleDeleteProject = React.useCallback(
     async (id: string) => {
       await deleteProjectInStore(id);
-      await listProjects();
       await refreshServers();
     },
-    [deleteProjectInStore, listProjects, refreshServers],
+    [deleteProjectInStore, refreshServers],
+  );
+
+  const handleUpdateProjectOptimization = React.useCallback(
+    async (id: string, optimization: ProjectOptimization) => {
+      return await updateProjectInStore(id, { optimization });
+    },
+    [updateProjectInStore],
   );
 
   // Show login screen for remote workspaces if not authenticated
@@ -997,6 +999,7 @@ const Home: React.FC = () => {
         onCreateProject={handleCreateProject}
         onRenameProject={handleRenameProject}
         onDeleteProject={handleDeleteProject}
+        onUpdateProjectOptimization={handleUpdateProjectOptimization}
       />
 
       {/* Advanced Settings Sheet */}

--- a/apps/electron/src/renderer/components/mcp/server/ProjectSettingsModal.tsx
+++ b/apps/electron/src/renderer/components/mcp/server/ProjectSettingsModal.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import type { Project } from "@mcp_router/shared";
+import {
+  DEFAULT_SEARCH_STRATEGY,
+  type Project,
+  type ProjectOptimization,
+  type ToolCatalogSearchStrategy,
+} from "@mcp_router/shared";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -18,6 +23,12 @@ import {
   DialogTitle,
   Input,
   ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
 } from "@mcp_router/ui";
 import { Pencil, Trash2, Info } from "lucide-react";
 import { toast } from "sonner";
@@ -30,6 +41,10 @@ type Props = {
   onCreateProject: (input: { name: string }) => Promise<Project>;
   onRenameProject: (id: string, updates: { name: string }) => Promise<Project>;
   onDeleteProject: (id: string) => Promise<void>;
+  onUpdateProjectOptimization: (
+    id: string,
+    optimization: ProjectOptimization,
+  ) => Promise<Project>;
 };
 
 export const ProjectSettingsModal: React.FC<Props> = ({
@@ -39,6 +54,7 @@ export const ProjectSettingsModal: React.FC<Props> = ({
   onCreateProject,
   onRenameProject,
   onDeleteProject,
+  onUpdateProjectOptimization,
 }) => {
   const { t } = useTranslation();
   const [newProjectName, setNewProjectName] = React.useState("");
@@ -83,7 +99,7 @@ export const ProjectSettingsModal: React.FC<Props> = ({
 
   const handleCreateProject = async () => {
     const name = newProjectName.trim();
-    if (!name) return; // keep light UX guard only for empty
+    if (!name) return;
     setCreating(true);
     try {
       await onCreateProject({ name });
@@ -141,6 +157,35 @@ export const ProjectSettingsModal: React.FC<Props> = ({
     } finally {
       setDeletingProjectId(null);
     }
+  };
+
+  const handleUpdateOptimization = (
+    project: Project,
+    optimization: ProjectOptimization,
+  ) => {
+    onUpdateProjectOptimization(project.id, optimization).catch(
+      (error: any) => {
+        console.error("Failed to save project optimization:", error);
+        const message = error?.message ?? "Failed to save settings.";
+        toast.error(message);
+      },
+    );
+  };
+
+  const handleToggleContextOptimization = (
+    project: Project,
+    enabled: boolean,
+  ) => {
+    // When enabling, use default strategy. When disabling, set to null.
+    const optimization = enabled ? DEFAULT_SEARCH_STRATEGY : null;
+    handleUpdateOptimization(project, optimization);
+  };
+
+  const handleChangeSearchStrategy = (
+    project: Project,
+    strategy: ToolCatalogSearchStrategy,
+  ) => {
+    handleUpdateOptimization(project, strategy);
   };
 
   return (
@@ -206,12 +251,18 @@ export const ProjectSettingsModal: React.FC<Props> = ({
                       {managedProjects.map((project) => {
                         const isEditing = editingProjectId === project.id;
                         const isDeleting = deletingProjectId === project.id;
+                        // optimization = null means disabled, otherwise enabled with strategy
+                        const contextOptEnabled = project.optimization !== null;
+                        const searchStrategy =
+                          project.optimization ?? DEFAULT_SEARCH_STRATEGY;
+
                         return (
                           <div
                             key={project.id}
                             className="flex items-center gap-3 px-3 py-2"
                           >
-                            <div className="flex-1">
+                            {/* Project name */}
+                            <div className="flex-1 min-w-0">
                               {isEditing ? (
                                 <Input
                                   value={editingName}
@@ -231,12 +282,61 @@ export const ProjectSettingsModal: React.FC<Props> = ({
                                   autoFocus
                                 />
                               ) : (
-                                <span className="text-sm font-medium">
+                                <span className="text-sm font-medium truncate block">
                                   {project.name}
                                 </span>
                               )}
                             </div>
-                            <div className="flex items-center gap-1">
+
+                            {/* Context Optimization settings (inline) */}
+                            {!isEditing && (
+                              <div className="flex items-center gap-2 shrink-0">
+                                <span className="text-xs text-muted-foreground">
+                                  {t("projects.contextOptimization", {
+                                    defaultValue: "Context Optimization",
+                                  })}
+                                </span>
+                                <Switch
+                                  checked={contextOptEnabled}
+                                  onCheckedChange={(checked) =>
+                                    handleToggleContextOptimization(
+                                      project,
+                                      checked,
+                                    )
+                                  }
+                                />
+                                {contextOptEnabled && (
+                                  <Select
+                                    value={searchStrategy}
+                                    onValueChange={(value) =>
+                                      handleChangeSearchStrategy(
+                                        project,
+                                        value as ToolCatalogSearchStrategy,
+                                      )
+                                    }
+                                  >
+                                    <SelectTrigger className="h-7 w-24">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="bm25">
+                                        {t("projects.searchStrategyBm25", {
+                                          defaultValue: "BM25",
+                                        })}
+                                      </SelectItem>
+                                      <SelectItem value="cloud">
+                                        {t("projects.searchStrategyCloud", {
+                                          defaultValue: "Advanced",
+                                        })}
+                                      </SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                )}
+                              </div>
+                            )}
+
+                            {/* Action buttons */}
+                            <div className="flex items-center gap-1 shrink-0">
                               {isEditing ? (
                                 <>
                                   <Button

--- a/apps/electron/src/renderer/components/mcp/server/ProjectSettingsModal.tsx
+++ b/apps/electron/src/renderer/components/mcp/server/ProjectSettingsModal.tsx
@@ -324,11 +324,6 @@ export const ProjectSettingsModal: React.FC<Props> = ({
                                           defaultValue: "BM25",
                                         })}
                                       </SelectItem>
-                                      <SelectItem value="cloud">
-                                        {t("projects.searchStrategyCloud", {
-                                          defaultValue: "Advanced",
-                                        })}
-                                      </SelectItem>
                                     </SelectContent>
                                   </Select>
                                 )}

--- a/apps/electron/src/renderer/components/setting/Settings.tsx
+++ b/apps/electron/src/renderer/components/setting/Settings.tsx
@@ -144,6 +144,7 @@ const Settings: React.FC = () => {
   // サブスクリプション情報の更新処理
   const handleRefreshSubscription = async () => {
     if (!isAuthenticated || isRefreshingSubscription) return;
+
     try {
       setIsRefreshingSubscription(true);
       await checkAuthStatus(true);
@@ -286,6 +287,10 @@ const Settings: React.FC = () => {
     userInfo?.planName && userInfo.planName.trim().length > 0
       ? userInfo.planName
       : t("settings.planNameUnknown");
+
+  const subscriptionDisplay = isSubscribed
+    ? planNameLabel
+    : t("settings.notSubscribed");
 
   return (
     <div className="p-6 flex flex-col gap-6">

--- a/apps/electron/src/renderer/stores/project-store.ts
+++ b/apps/electron/src/renderer/stores/project-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { Project } from "@mcp_router/shared";
+import type { Project, ProjectOptimization } from "@mcp_router/shared";
 import { UNASSIGNED_PROJECT_ID as SHARED_UNASSIGNED_PROJECT_ID } from "@mcp_router/shared";
 import { useWorkspaceStore } from "./workspace-store";
 
@@ -15,7 +15,10 @@ interface ProjectStoreState {
   // Actions
   list: () => Promise<void>;
   create: (input: { name: string }) => Promise<Project>;
-  update: (id: string, updates: { name?: string }) => Promise<Project>;
+  update: (
+    id: string,
+    updates: { name?: string; optimization?: ProjectOptimization },
+  ) => Promise<Project>;
   delete: (id: string) => Promise<void>;
 
   // UI state actions

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,225 @@
+# 検出事項の詳細
+
+## 1. OAuth および認証トークンセキュリティの脆弱性 (深刻度: 緊急)
+
+### 対象の機能
+OAuth および認証トークンセキュリティの脆弱性
+
+### 該当箇所
+- apps/electron/src/main/modules/auth/auth.service.ts
+- apps/electron/src/main.ts
+- apps/electron/src/main/infrastructure/shared-config-manager.ts
+- apps/electron/src/main/modules/settings/settings.service.ts
+- apps/electron/src/main/modules/workspace/workspace.ipc.ts
+- apps/electron/src/main/modules/auth/auth.ipc.ts
+
+auth.service.ts の handleAuthToken 関数 (94-119 行目) - currentAuthState が null の場合にステート検証をバイパスし、任意のトークンを処理し、SharedConfigManager にプレーンテキストで保存します。
+
+### 説明
+認証トークン処理における複数の重大な欠陥: 1) PKCE OAuth フローのステートパラメータ検証は、currentAuthState が存在しない場合にバイパス可能であり、CSRF 攻撃とプロトコルハンドラー URL の操作を可能にします。2) 認証トークンは暗号化なしでプレーンテキストで保存され、保護なしで IPC を介して送信されます。3) getDecryptedAuthToken() 関数は誤解を招くように暗号化を示していますが、プレーンテキストトークンを返します。4) 認証トークンとワークスペースの資格情報は、適切な認証チェックなしで IPC ハンドラーを介して公開されます。5) トークンローテーションメカニズムが存在しないため、侵害されたトークンが永続的な脅威となります。
+
+### リスク
+この脆弱性により、攻撃者は認証をバイパスし、ユーザーアカウントへの不正アクセスを取得できます。これにより、データの漏洩、アカウントの乗っ取り、および機密情報の改ざんが発生する可能性があります。また、攻撃者は、悪意のある操作を実行し、ユーザーをなりすます可能性があります。対策を講じないと、重大なセキュリティインシデントにつながる可能性があります。
+
+### 対策
+この脆弱性に対処するために、以下の対策を講じる必要があります:
+
+•  **OAuth フローの改善**: PKCE OAuth フローのステートパラメータ検証を確実に実装し、currentAuthState が存在する場合にのみ実行されるようにします。
+•  **トークンストレージの暗号化**: 認証トークンを暗号化された形式で保存するように変更します。安全なストレージメカニズムを使用し、キー管理を適切に実装します。
+•  **IPC ハンドラーの認証**: IPC ハンドラーに適切な認証チェックを追加して、承認されたプロセスのみが機密データにアクセスできるようにします。ワークスペース資格情報へのアクセスを厳密に制限します。
+•  **トークンローテーションの導入**: 定期的なトークンローテーションを実装して、侵害されたトークンの影響を軽減します。トークンの有効期限を適切に設定し、新しいトークンを定期的に発行します。
+•  **getDecryptedAuthToken() の修正**: 関数名が誤解を招く可能性を避けるために、関数の名前を変更するか、プレーンテキストトークンを返す場合には、その動作を明確にドキュメント化します。
+
+## 2. URLインジェクションによるサーバーサイドリクエストフォージェリ (SSRF) (深刻度: 緊急)
+
+### 対象の機能
+URLインジェクションによるサーバーサイドリクエストフォージェリ (SSRF)
+
+### 該当箇所
+- apps/electron/src/main/utils/fetch-utils.ts
+- apps/electron/src/main/modules/workspace/platform-api-manager.ts
+- apps/electron/src/main/modules/mcp-apps-manager/mcp-client.ts
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ts
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts
+- apps/electron/src/main/modules/system/system-handler.ts
+
+Line 29-31 in fetch-utils.ts: const url = path.startsWith('http') ? path : `${apiBaseUrl}${path.startsWith('/') ? '' : '/'}${path}`; return fetch(url, options); OR Line 50 in mcp-client.ts: const transport = new StreamableHTTPClientTransport(new URL(server.remoteUrl)) OR Line 199 in platform-api-manager.ts: return this.currentWorkspace.remoteConfig.apiUrl;
+
+### 説明
+不十分なURL検証による複数のSSRF脆弱性: 1) `fetchWithToken`関数は、パスが'http'で始まる場合に任意のURLを許可します。2) リモートワークスペース設定は、APIリクエストに直接使用される任意の`apiUrl`値を許可します。3) MCPサーバー接続は、検証なしにユーザーが提供した`remoteUrl`パラメータを受け入れます。4) サーバー設定のテストとフィードバックの送信は、攻撃者が制御するエンドポイントへのリクエストを行います。これにより、内部サービスへのアクセス、ネットワークスキャン、資格情報の抽出、およびクラウドメタデータエンドポイントへのデータアクセスが可能になります。
+
+### リスク
+この脆弱性により、攻撃者は内部サービスにアクセスし、機密情報を盗み、内部ネットワークをスキャンし、場合によってはサーバーを完全に侵害する可能性があります。これは、データの漏洩、サービスの中断、および潜在的な財務的損失につながる可能性があります。
+
+### 対策
+この脆弱性を修正するには、次の対策を実装してください。• すべてのユーザー提供URLに対して厳格な検証を実施し、許可されたドメインのホワイトリストを使用します。• ユーザーからの入力を受け入れる前に、`apiUrl`を含むすべてのURLをサニタイズします。• リモートサーバーの構成に使用される`remoteUrl`パラメータをサニタイズします。• 内部リソースへのアクセスを制限し、SSRF攻撃が成功した場合の潜在的な影響を軽減します。• ネットワーク上で外部リクエストをブロックするファイアウォールルールを構成します。
+
+## 3. トークン管理とアクセス制御バイパスの脆弱性 (深刻度: 緊急)
+
+### 対象の機能
+トークン管理とアクセス制御バイパスの脆弱性
+
+### 該当箇所
+- apps/electron/src/main/modules/mcp-apps-manager/token-manager.ts
+- apps/electron/src/main/infrastructure/shared-config-manager.ts
+- apps/electron/src/main/modules/mcp-server-manager/server-service.ts
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts
+
+`TokenManager.validateToken()` は、トークンの存在のみをチェックし（50〜64行目）、有効期限を無視します。`shared-config-manager.ts` の `syncTokensWithWorkspaceServers()` は、すべてのサーバーIDを既存のトークンのserverAccessに自動的に追加します（354〜370行目）。移行コードは、すべてのワークスペースサーバーへのアクセスを許可します（222〜228行目）。`ServerService.addServer()` は、新しいサーバーへのアクセスをすべてのトークンに許可します（53〜70行目）。
+
+### 説明
+トークンとサーバー管理における重大な認証の欠陥。
+
+• トークン有効期限メカニズムがないため、トークンは無期限に有効です。
+• トークン生成は、適切な認証チェックなしに既存のトークンを削除します。
+• `syncTokensWithWorkspaceServers()` は、許可検証なしに既存のトークンに対してすべてのワークスペースサーバーへのアクセスを自動的に付与します。
+• データベース移行中、トークンは元の許可に関係なくすべてのサーバーへのアクセスを受け取ります。
+• IPCハンドラーは、サーバーの開始/停止や設定の変更などの機密性の高い操作を実行する前に、許可検証を欠いています。
+
+### リスク
+この脆弱性により、攻撃者は未承認のアクセスを得て、機密データにアクセスしたり、システムを制御したりすることが可能になります。トークンが無期限に有効であるため、既存のトークンが削除されずに新しいサーバーへのアクセス権が自動的に付与されると、攻撃者は永続的なアクセス権を得て、システムを長期間にわたって侵害する可能性があります。データベース移行中や新しいサーバーが作成された際に、すべてのサーバーへのアクセス権がトークンに自動的に付与されることも、広範囲にわたる影響を引き起こす可能性があります。さらに、IPCハンドラーの認証チェックの欠如は、サーバーの制御や設定変更などの機密操作への不正アクセスを可能にし、さらなるリスクを高めます。
+
+### 対策
+この脆弱性を解決するための主な対策は次のとおりです。
+
+• **トークン有効期限の実装**: トークンに有効期限を設け、定期的に失効させるメカニズムを導入します。有効期限が切れたトークンは無効化されるべきです。
+• **トークン生成時の認証強化**: トークンを生成する際に、既存のトークンを削除する前に、適切な認証チェック（権限確認）を行うようにします。ユーザーが自分のトークンを削除する権限を持っていることを確認する必要があります。
+• **アクセス制御の厳格化**: `syncTokensWithWorkspaceServers()` 関数やデータベース移行処理において、すべてのサーバーへの自動的なアクセス許可を付与するのではなく、適切な権限検証を行い、必要なアクセス権のみを付与するように変更します。
+• **IPCハンドラーの認証**: IPCハンドラーで機密性の高い操作（サーバーの開始/停止、設定変更など）を実行する前に、必ず認証チェックを実施します。これにより、不正なアクセスを防ぎ、システムの安全性を高めます。
+
+## 4. パス・トラバーサルとファイルシステムアクセス脆弱性 (深刻度: 緊急)
+
+### 対象の機能
+パス・トラバーサルとファイルシステムアクセス脆弱性
+
+### 該当箇所
+- apps/electron/src/main/utils/uri-utils.ts
+- apps/electron/src/main/modules/mcp-server-runtime/request-handlers.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/mcp-server-manager/dxt-processor/dxt-processor.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/mcp-server-manager/dxt-processor/dxt-converter.ts
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/workspace/workspace.service.ts
+- mcp-router/mcp-router/apps/electron/src/main/infrastructure/database/sqlite-manager.ts
+
+parseResourceUri() extracts path without validation: path: match[2] containing traversal sequences; workspace.service.ts constructs paths: path.join(app.getPath("userData"), dbPath) where dbPath contains "../../../etc/passwd"
+
+### 説明
+複数のコンポーネントにわたる複数のパス・トラバーサル脆弱性：1） `parseResourceUri` 関数は、リソースURIでパス・トラバーサルシーケンスを許可する不十分な正規表現検証を使用します。2） DXTファイル処理は、`unpackExtension()` と `expandPathVariables()` を介してパス検証なしで任意のファイル抽出を許可します。3）IPCハンドラーは、`server:selectFile` と任意のディレクトリ作成を介してファイルシステム操作を許可します。4）ワークスペースデータベースパスの構築は、トラバーサルシーケンスを含む可能性のあるユーザー制御の入力を利用します。これらの脆弱性により、不正なファイルアクセス、システムファイルの上書き、および悪意のある実行可能ファイルの配置が可能になります。
+
+### リスク
+この脆弱性の主なリスクは、攻撃者が任意のファイルにアクセスし、システムファイルを上書きし、悪意のある実行可能ファイルを配置できることです。これにより、システムが完全に侵害され、機密データが漏洩する可能性があります。影響範囲には、ユーザーアカウント、個人情報、およびシステム設定への不正アクセスが含まれます。
+
+### 対策
+この脆弱性を修正するには、以下の対策を講じる必要があります。•　すべてのパス入力を厳密に検証し、パス・トラバーサルシーケンスを拒否する。具体的には、`parseResourceUri` 関数で、抽出されたパスコンポーネントを安全に検証する正規表現を使用する。•　DXTファイル処理でパス検証を実装し、ファイルが意図したディレクトリ外に書き込まれないようにする。•　`server:selectFile` などのIPCハンドラーへの入力も検証する。•　ワークスペースデータベースパスの構築時に、ユーザー制御の入力からパス・トラバーサルシーケンスを除去するためのサニタイズを行う。•　ファイルシステムへのアクセスを制限するために、最小権限の原則を適用する。•　安全なファイルシステム操作ライブラリの使用を検討する。
+
+## 5. フックおよびワークフローシステムを介した任意のコード実行 (深刻度: 緊急)
+
+### 対象の機能
+フックおよびワークフローシステムを介した任意のコード実行
+
+### 該当箇所
+- apps/electron/src/main/modules/workflow/hook.ipc.ts
+- apps/electron/src/main/modules/workflow/workflow.ipc.ts
+- apps/electron/src/main/modules/workflow/hook.service.ts
+- apps/electron/src/main/modules/workflow/workflow-executor.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/workflow/hook.repository.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/workflow/workflow.repository.ts
+- apps/electron/src/main/modules/mcp-server-runtime/request-handler-base.ts
+
+hook.service.ts line 196: vmScript.runInContext(vmContext, {timeout: 5000}) - where vmContext contains escapable sandbox with Object/Array constructors allowing access to Node.js process object
+
+### 説明
+ワークフロー/フックシステムにおける重要なコード実行の脆弱性: 1) フックおよびワークフローIPCハンドラーは、適切なサンドボックス化なしに、メインプロセスのコンテキストで実行される任意のJavaScriptコードを受け入れます。 2) VMサンドボックスの実装が不十分であり、攻撃者はプロトタイプ汚染、コンストラクタ操作、またはNode.js組み込みモジュールへのアクセスを通じて脱出できます。 3) 保存されたフックスクリプトとワークフロー定義には、データベースから取得され、検証なしで実行される実行可能なJavaScriptが含まれています。 4) ワークフローの実行は、MCPリクエストの通常の認証/認可をバイパスします。 5) フックスクリプトは、トークンや機密データを含む広範なコンテキストを受け取ります。 これらにより、完全な権限昇格とシステム侵害が可能になります。
+
+### リスク
+この脆弱性は、攻撃者が任意のコードを実行することを可能にし、システムの完全な侵害につながる可能性があります。 攻撃者は、システムのすべてのデータにアクセスし、機密情報を盗み、他のシステムを侵害し、サービスの**DoS**を引き起こす可能性があります。 このような脆弱性は、企業にとって深刻な脅威となり、評判と財務に大きな損害を与える可能性があります。
+
+### 対策
+この脆弱性を修正するための解決策は、次のとおりです。まず、フックモジュールとワークフローのIPCハンドラーからの入力に対して、より厳密な検証とサニタイズを実装します。次に、JavaScriptコードを実行するためのより安全なサンドボックス環境を実装します。これは、Node.jsの組み込みモジュールへのアクセスを制限し、プロトタイプ汚染などの攻撃を防ぐように設計されている必要があります。また、データベースに保存されているフックスクリプトとワークフロー定義が、実行前に検証されることを確認してください。最後に、ワークフローの実行が通常の認証/認可プロセスをバイパスしないようにしてください。
+
+## 6. 機密認証データの暗号化されていない保存 (深刻度: 緊急)
+
+### 対象の機能
+機密認証データの暗号化されていない保存
+
+### 該当箇所
+- mcp-router/mcp-router/apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.repository.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/workspace/workspace.repository.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/mcp-logger/mcp-logger.repository.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/auth/auth.service.ts
+- mcp-router/mcp-router/apps/electron/src/main/modules/settings/settings.repository.ts
+
+1) mcp-server-manager.repository.ts の 235 行目: `bearer_token: bearerToken` はプレーンテキストトークンを保存します 2) shared-config-manager.ts の 117 行目: JSON.stringify はプレーンテキスト authToken をファイルに保存します 3) workspace.repository.ts の 160 行目: 暗号化なしの base64 でエンコードされたトークン 4) mcp-logger.repository.ts の 149 行目: JSON.stringify は機密リクエストパラメーターを保存する可能性があります
+
+### 説明
+機密認証トークン (ベアラトークン、認証トークン) が、暗号化なしでSQLiteデータベース内にプレーンテキストとして保存されています。トークンは、サーバー設定、ワークスペース設定、およびアプリケーション設定にプレーンJSONとして保存されます。リクエストログにもこれらのトークンがパラメーターまたはレスポンスに含まれる可能性があり、データベースアクセス、ログファイルの分析、バックアップの調査、またはメモリダンプを通じて複数のエクスポージャーベクトルが作成されます。
+
+### リスク
+この脆弱性の主なリスクは、攻撃者が認証トークンを盗み、その結果、アプリケーションに完全にアクセスできるようになることです。これは、機密情報の漏洩、データの改ざん、およびサービスの完全な侵害につながる可能性があります。
+
+### 対策
+この脆弱性を修正するための最優先事項は、すべての機密認証データを暗号化することです。これには、ベアラトークン、認証トークン、およびその他の機密資格情報が含まれます。
+
+• 対称暗号化アルゴリズム（AESなど）を使用して、トークンを保存する前に暗号化します。
+• 暗号化されたトークンを安全なストレージに保存します。
+• キー管理を安全に実装し、暗号化キーを保護します。
+• 可能であれば、トークンの有効期間を短くし、定期的にローテーションします。
+• リクエストログから機密認証データを削除します。
+
+さらに、アプリケーション設定とログに機密データがプレーンテキストで保存されていないことを確認してください。
+
+## 7. HTTP サーバー入力処理の脆弱性 (深刻度: 高)
+
+### 対象の機能
+HTTP サーバー入力処理の脆弱性
+
+### 該当箇所
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts
+
+```
+Lines 76-80: const tokenId = typeof token === "string" ? token.startsWith("Bearer ") ? token.substring(7) : token : ""; and Lines 184: skipValidation: platformManager.isRemoteWorkspace() in resolveProjectFilter method
+```
+
+### 説明
+HTTPサーバーの処理における複数の入力検証の欠陥:
+
+1) Bearer トークン認証には二重の処理ロジック（58～61行目と76～80行目）があり、認証をバイパスする可能性のある、一貫性のない検証動作を引き起こしています。
+2) resolveProjectFilter メソッドは、プロジェクトヘッダーの値に対して不十分な検証を行っており、基本的なトリミングのみを実行し、最初の配列要素を取得しています。これにより、特に検証が完全にスキップされるリモートワークスペースモードでは、プロジェクトヘッダーインジェクションによりアクセス制御をバイパスする可能性があります。
+
+### リスク
+この脆弱性は、不正なアクセス制御につながる可能性があります。攻撃者は、認証をバイパスして、機密データにアクセスしたり、システム上で不正な操作を実行したりする可能性があります。プロジェクトヘッダーインジェクション攻撃は、特にリモートワークスペースモードで、意図しないプロジェクトへのアクセスを可能にし、さらなる攻撃につなげられる可能性があります。
+
+### 対策
+この脆弱性を修正するには、以下の対策を講じる必要があります。
+
+•  **Bearer トークン認証の修正:** 一貫性のある認証ロジックを実装し、トークン処理の一貫性を確保してください。トークンの処理と検証において、同じトークン変数を使用するように修正してください。
+•  **プロジェクトヘッダー検証の強化:** プロジェクトヘッダーの検証を強化し、潜在的なインジェクション攻撃を防いでください。ヘッダー値の適切な検証を行い、不正な値が使用されないようにしてください。リモートワークスペースモードでも、適切な検証が行われるように実装を変更してください。
+•  **入力検証の徹底:** HTTP サーバーへのすべての入力に対して、厳密な入力検証を実行してください。これにより、不正な入力がシステムに影響を与えるのを防ぐことができます。
+
+## 8. ワークフローエンジンにおけるDoSと情報漏洩 (深刻度: 高)
+
+### 対象の機能
+ワークフローエンジン
+
+### 該当箇所
+- apps/electron/src/main/modules/workflow/workflow-executor.ts
+- apps/electron/src/main/modules/workflow/hook.service.ts
+- apps/electron/src/main/modules/workflow/workflow.service.ts
+- apps/electron/src/main/modules/mcp-server-runtime/request-handler-base.ts
+
+`hook.service.ts:196-203` のフックスクリプト実行において、`vmScript.runInContext(vmContext, {timeout: 5000})` が、トークン、クライアントID、MCPレスポンスを含むコンテキストデータへの完全なアクセス権を持つユーザー提供のスクリプトを実行し、漏洩のためにログに記録または返却される可能性があります。
+
+### 説明
+ワークフローシステムにおけるDoSとデータ漏洩につながる脆弱性。
+1) ワークフローグラフにサイクルがあると、`determineExecutionOrder()` で検出をバイパスし、無限実行を引き起こす可能性があります。2) ワークフローの複雑性が過度であると、BFS/トポロジカルソート処理においてアルゴリズム的なDoSを引き起こします。3) 無限ループまたはリソースを大量に消費する操作を含むフックスクリプトは、タイムアウトにもかかわらず、CPU/メモリを大量に消費します。4) フックスクリプトは、MCPパラメータ、クライアントID、トークン、内部状態を含む機密性の高いコンテキスト情報を受け取り、コンソールログ記録または戻り値操作を通じて漏洩させる可能性があります。
+
+### リスク
+この脆弱性の主なリスクは、攻撃者がDoSを引き起こし、また、ワークフロー内の機密性の高いコンテキストデータを盗み出すことができることです。このデータには、MCPパラメータ、クライアントID、トークン、内部状態が含まれており、これらは、不正アクセス、アカウントの乗っ取り、またはその他の悪意のある活動に使用される可能性があります。DoS攻撃は、ワークフローエンジンの可用性に影響を与え、サービスの中断やパフォーマンスの低下につながる可能性があります。この脆弱性の潜在的な影響は、データの機密性と可用性の両方に関係し、高いリスクをもたらします。
+
+### 対策
+この脆弱性を修正するための推奨事項は次のとおりです。
+• ワークフローグラフのサイクル検出を強化し、無限実行を防止する。
+• ワークフローの複雑性を制限し、アルゴリズムDoSを回避する。
+• フックスクリプトの実行をより厳密に制御し、リソースを大量に消費する操作や無限ループを防止する。
+• フックスクリプトがアクセスできるコンテキストデータの範囲を制限し、機密データの漏洩を防ぐ。
+• コンテキストデータのエスケープと検証を実装して、情報漏洩のリスクを軽減する。

--- a/docs/SECURITY_LISTUP.md
+++ b/docs/SECURITY_LISTUP.md
@@ -1,0 +1,78 @@
+1. OAuth/認証トークンの脆弱性（緊急）
+
+- apps/electron/src/main/modules/auth/auth.service.ts:94 — handleAuthToken のステート検証を厳格化（state/currentAuthState未設定時は拒否）。引数名もcodeへ明確化。
+- apps/electron/src/main/modules/auth/auth.service.ts:223 — getDecryptedAuthToken は平文返却。実際に暗号化実装へ変更、もしくは関数名/仕様の整合。
+- apps/electron/src/main/modules/auth/auth.service.ts:255 — status() が token を返すのを停止（レンダラーへトークン渡さない）。
+- apps/electron/src/main/modules/auth/auth.ipc.ts:22 — auth:status の返り値からトークン等の秘匿情報排除。認可チェックの導入。
+- apps/electron/src/main/modules/auth/auth.ipc.ts:36 — auth:handle-token 呼出し元検証/レート制限/再入防止。
+- apps/electron/src/main/modules/workspace/workspace.ipc.ts:50 — workspace:get-credentials の廃止か認可ガード（UIへ資格情報を出さない）。
+- apps/electron/src/main/infrastructure/shared-config-manager.ts:104 — 設定保存（saveConfig）で平文保存→安全保管（OS Keychain/Keytarや暗号化+安全な鍵管理）。
+- apps/electron/src/preload.ts:160 — getWorkspaceCredentials や onAuthStatusChanged の露出内容見直し（秘匿情報を橋渡ししない）。
+- apps/electron/src/main.ts:444 — handleProtocolUrl の受け取る mcpr:// URL を用途限定で厳格パース（認証フロー以外は拒否）。
+
+2. SSRF（URLインジェクション）（緊急）
+
+- apps/electron/src/main/utils/fetch-utils.ts:28 — http/https 始まりの任意URL許容を廃止。許可リストベースのベースURL連結のみ許可。
+- apps/electron/src/main/modules/mcp-apps-manager/mcp-client.ts:50 — new URL(server.remoteUrl) の前にスキーム/ホスト/パス検証（https限定、内部/ローカル禁止等）。
+- apps/electron/src/main/modules/mcp-apps-manager/mcp-client.ts:81 — SSEの remoteUrl も同様に検証。
+- apps/electron/src/main/modules/workspace/platform-api-manager.ts:208 — remoteConfig.apiUrl を採用する前に保存時/読取時の検証（許可ドメイン/スキーム）。
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts:26 — 追加/更新時に remoteUrl/bearerToken の厳格バリデーション（プロトコル、ポート、プライベートアドレス禁止）。
+- apps/electron/src/main/modules/system/system-handler.ts:30 — フィードバック送信先は固定のみ許可。将来の設定化時は厳格バリデーション。
+
+3. トークン管理/アクセス制御バイパス（緊急）
+
+- apps/electron/src/main/modules/mcp-apps-manager/token-manager.ts:46 — validateToken に有効期限・失効・スコープ検証を追加。
+- apps/electron/src/main/modules/mcp-apps-manager/token-manager.ts:13 — 生成トークンへ expiresAt 等の期限/ローテーション属性付与。
+- apps/electron/src/main/modules/mcp-server-manager/server-service.ts:41 — 新規サーバー時に全トークンへ自動許可付与を削除（明示的許可フローへ）。
+- apps/electron/src/main/infrastructure/shared-config-manager.ts:351 — syncTokensWithWorkspaceServers による一括許可付与の廃止/同意ベース。
+- apps/electron/src/main/infrastructure/shared-config-manager.ts:222 — マイグレーション時「全サーバー付与」を廃止（最小権限での移行）。
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts:9 — 開始/停止/更新系IPCに認可チェック導入。
+
+4. パス・トラバーサル/FSアクセス（緊急）
+
+- apps/electron/src/main/utils/uri-utils.ts:10 — parseResourceUri の path に ../スキーム混入を許さない正規化/検証。
+- apps/electron/src/main/modules/mcp-server-runtime/request-handlers.ts:435 — readResourceByUri で createUriVariants に生のパスを渡す前に許可スキーム/サーバ側制約を適用。
+- apps/electron/src/main/modules/mcp-server-manager/dxt-processor/dxt-processor.ts:45 — unpackExtension 抽出先の脱出防止（Zip Slip対策、展開先検証）。
+- apps/electron/src/main/modules/mcp-server-manager/dxt-processor/dxt-converter.ts:162 — パス変数展開後に正規化と許可ディレクトリ外排除。
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.ipc.ts:91 — server:selectFile の受け入れ制限（mode/filters強制、パス検証）。
+- apps/electron/src/main/modules/workspace/workspace.service.ts:432 — databasePath をユーザー入力にさせない/正規化（トラバーサル拒否）。
+- apps/electron/src/main/infrastructure/database/sqlite-manager.ts:17 — 相対入力時のパス合成で正規化と検査（.. 排除）。
+
+5. フック/ワークフロー経由の任意コード実行（緊急）
+
+- apps/electron/src/main/modules/workflow/hook.service.ts:206 — vm.runInContext サンドボックス強化（Object/Array/Pipelineの凍結、require/プロセス遮断、I/O禁止）。
+- apps/electron/src/main/modules/workflow/hook.ipc.ts:10 — 作成/更新/実行IPCに厳格バリデーションと認可（管理者のみ等）。
+- apps/electron/src/main/modules/workflow/workflow.ipc.ts:10 — 同上（有効化/実行時の検証）。
+- apps/electron/src/main/modules/mcp-server-runtime/request-handler-base.ts:39 — ワークフロー実行コンテキストからトークン/機密除去、またはダミー化。
+- apps/electron/src/main/modules/workflow/workflow.repository.ts:... — 保存前のスクリプト検証/署名/サイズ上限等の防御策。
+
+6. 機密データの平文保存（緊急）
+
+- apps/electron/src/main/modules/mcp-server-manager/mcp-server-manager.repository.ts:235 — bearer_token を暗号化保存（Keytar等、KMSが望ましい）。
+- apps/electron/src/main/infrastructure/shared-config-manager.ts:116 — settings.authToken 等をファイルへ平文保存しない（安全保管へ移行）。
+- apps/electron/src/main/modules/workspace/workspace.repository.ts:160 — Base64疑似「暗号化」を廃止。真正な暗号化＋鍵管理に変更。
+- apps/electron/src/main/modules/mcp-logger/mcp-logger.repository.ts:146 — request_params/response_data に秘匿情報混入を除去/マスキング、必要最小限のみ保存。
+- apps/electron/src/renderer/stores/auth-store.ts:122 — レンダラー状態に authToken を保持しない（必要時のみ一時メモリ、極力メイン側処理）。
+
+7. HTTPサーバー入力処理（高）
+
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts:56 — Bearerトークン処理の二重/不整合を統一（前処理/後処理の一本化）。
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts:110 — resolveProjectFilter の検証強化（フォーマット/長さ/存在確認、remoteでも検証をスキップしない）。
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts:47 — cors() を許可オリジン限定へ。express.json({limit}) でサイズ制限。
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts:390 — listen(port) を listen(port, '127.0.0.1') へ（ローカルバインド）。TLS導入も検討。
+- apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts:145 — _meta.token 付与を廃止/最小化（下流/ログへ秘匿情報を流さない）。
+
+8. ワークフローのDoS/情報漏洩（高）
+
+- apps/electron/src/main/modules/workflow/workflow-executor.ts:210 — グラフ検証を強化（サイクル検出の堅牢化、ノード/エッジ上限、タイムアウト/ステップ制限）。
+- apps/electron/src/main/modules/workflow/hook.service.ts:206 — フックスクリプトのCPU/メモリ消費制限、実行回数・最大出力制限。
+- apps/electron/src/main/modules/mcp-server-runtime/request-handler-base.ts:39 — コンテキスト/ログから機密情報を除去（最小限メタのみ）。
+- apps/electron/src/main/modules/workflow/workflow.service.ts:119 — 有効化時の検証を厳格化（構造/負荷/権限チェックを必須化）。
+
+補足（推奨の横断対応）
+
+- apps/electron/src/main.ts:295 — CSPは本番で unsafe-eval/unsafe-inline を禁止。開発時のみ緩める。
+- apps/electron/src/renderer/components/mcp/apps/McpAppsManager.tsx:303 — dangerouslySetInnerHTML の除去か厳格サニタイズ（XSS対策）。
+- 全IPCに入力スキーマ検証（zod等）と認可ガード、レート制限を導入。ログは秘匿情報を常時マスク。
+
+必要なら、このリストをチェックリスト化（優先度/工数見積もり付き）や、具体的な修正PRの下準備まで対応します。

--- a/docs/design/tool-catalog-plan.md
+++ b/docs/design/tool-catalog-plan.md
@@ -1,0 +1,224 @@
+# Tool Catalog & Search 設計
+
+## TL;DR
+- 検索/実行は固定の MCP メタツール `tool_discovery` / `tool_execute` で提供し、動的なツール追加は行わない。
+- 検索リクエスト時に Available Tool List を収集し、クラウド Search API で検索。失敗時はローカル BM25 にフォールバック。
+- token・project・`tool_permissions`・稼働状況によるフィルタはローカルで適用する。検索対象/結果はツールのみ。
+- UI 変更は最小限。検索 UI/CLI は増やさず、フロントはメタツール経由で利用する。
+
+## 現状と課題
+- `AggregatorServer` + `RequestHandlers` が複数 MCP サーバを集約し、HTTP 入口 `MCPHttpServer` は `_meta.token/_meta.projectId` を付与して転送。
+- サーバ設定・稼働状態は `MCPServerManager` + SQLite（`servers.tool_permissions` を含む）で保持。ツール/リソース/プロンプトのメタは永続化せず、毎回 `listTools/listResources/listPrompts` で取得。
+- ワークスペース切替時に DB/サービスはリセット。`PlatformAPI` にカタログ検索系がなく、UI/CLI から検索不可。LLM も固定メタツールがなく、自然文検索/指定実行ができない。
+
+## ゴールと非ゴール
+
+### Phase 1: ローカル検索（現在）
+- ゴール
+  - `tool_discovery` / `tool_execute` を通じて LLM/既存 MCP クライアントがプロジェクト/トークン境界を保ったまま検索・実行できる。
+  - BM25 アルゴリズムによるローカル検索を提供する。
+  - 検索リクエスト時に Available Tool List を動的に収集し、事前のインデックス化は不要とする。
+- 非ゴール
+  - CLI 向け新規コマンドや検索専用 UI の追加は行わない。
+  - ツール実行回数の集計やレコメンドは後続。
+  - `listTools` で動的に全ツールを追加/更新することはしない（固定2ツールのみ）。
+  - プロンプト/リソースの検索は対象外。
+  - ローカルにカタログ DB を永続化しない。
+
+### Phase 2: クラウド検索（後続）
+- ゴール
+  - クラウド Search API による高度な検索（LLMベース選択など）を提供する。
+  - フォールバック戦略: クラウド Search API → 失敗 → ローカル BM25 にフォールバック。
+- 非ゴール
+  - クラウドへのカタログ同期（Available Tool List はリクエスト時に送信するため不要）。
+
+## ユースケース/要求
+- 機能: 自然文クエリ＋`maxResults` でツール検索し、スコア付き結果を返す。
+- 実行: `tool_execute` で `toolKey`/`arguments` を指定して実行し、`tool_permissions`/稼働状況/トークン境界を検証する。
+- 監査: 検索リクエストを `mcp-logger` に記録する。
+- セキュリティ: token 未指定時の扱いを明確化（デフォルト拒否）。`tool_permissions=false` は検索対象外。`projectId` 不一致は除外。
+
+## アーキテクチャ概要
+- ローカル: 検索リクエスト時に稼働中サーバから Available Tool List を収集し、検索プロバイダーに委譲。
+- 検索プロバイダー: クラウド Search API（優先）→ ローカル BM25（フォールバック）。
+- 入口: 検索/実行は MCP メタツールに統一。
+
+## プロジェクト設定
+
+ツールカタログはプロジェクト毎に設定を保持できる。設定は `projects` テーブルの `optimization` カラムに保存される。
+
+### 設定項目
+```typescript
+// packages/shared/src/types/project-types.ts
+type ToolCatalogSearchStrategy = 'bm25' | 'cloud';
+type ProjectOptimization = ToolCatalogSearchStrategy | null;
+
+// projects.optimization カラム: ProjectOptimization
+// - null: ツールカタログ無効
+// - 'bm25': ローカル BM25 検索
+// - 'cloud': クラウド検索（Phase 2 で実装予定）
+```
+
+### 動作
+- `optimization = null` の場合、`tool_discovery` は空の結果を返す。
+- `optimization = 'cloud'` を選択していても、クラウド検索が利用不可の場合は BM25 にフォールバック。
+
+### UI
+- プロジェクト設定モーダル（歯車アイコン）から「Context Optimization」を編集可能。
+- トグル OFF → `optimization = null`（無効）
+- トグル ON + 戦略選択 → `optimization = 'bm25'` または `'cloud'`
+
+## コンポーネントと責務
+
+### ローカル (Router/Electron)
+- ToolCatalogService（統合サービス）: 以下の機能を統合して提供。
+  - **ツールリスト収集**: 検索リクエスト時に `MCPServerManager` が保持する稼働サーバから `listTools` を実行し、`tool_permissions`/`projectId`/`serverStatusMap` でフィルタした Available Tool List を構築。
+  - **検索プロバイダー管理**: クラウド Search API → ローカル BM25 のフォールバック戦略を実装。
+- SearchProvider インターフェース: 検索アルゴリズムの抽象化。
+  - `BM25SearchProvider`: ローカル BM25 検索（フォールバック用）。
+  - `CloudSearchProvider`（後続）: クラウド Search API 呼び出し。
+- RequestHandlers（メタツール）: `AggregatorServer`/`RequestHandlers` に `tool_discovery` / `tool_execute` を追加。`CallTool` で捕捉し、`ToolCatalogService` に委譲。`ListTools` は固定2ツールのみを返す。
+- Logging: `tool_discovery`/`tool_execute` 呼び出し結果を `mcp-logger` に送出。
+
+### クラウド（後続）
+- Search API: `/catalog/search` で Available Tool List と Query を受け取り、適切なツールを選択して返却。
+- Auth: Router 発行トークンを Bearer で検証。`projectId` 境界でのアクセス制御を行う。
+
+## API とスキーマ
+
+### クラウド REST（案）
+- `POST /catalog/search`
+  ```ts
+  type ToolInfo = {
+    toolKey: string; // `${serverId}:${toolName}`
+    toolName: string;
+    serverName: string;
+    description?: string;
+  };
+  type SearchRequest = {
+    query: string[]; // Search Queries
+    context?: string; // Background information or task description
+    tools: ToolInfo[]; // Available Tool List
+    maxResults?: number;
+  };
+  type SearchResult = {
+    toolKey: string;
+    toolName: string;
+    serverName: string;
+    description?: string;
+    relevance: number;      // 0-1 正規化スコア
+    explanation?: string;   // 選択理由
+  };
+  type SearchResponse = { results: SearchResult[] };
+  ```
+
+### MCP メタツール `tool_discovery`
+- Input（CallTool `arguments`）:
+  ```ts
+  {
+    query: string[]; // Search Queries
+    context?: string; // Background information or task description (for Cloud search)
+    maxResults?: number;
+  }
+  ```
+- Output:
+  ```ts
+  {
+    results: Array<{
+      toolKey: string;
+      toolName: string;
+      serverName: string;
+      description?: string;
+      relevance: number;      // 0-1 正規化スコア
+      explanation?: string;   // 任意の説明（選択理由など）
+    }>;
+  }
+  ```
+- 実装:
+  1. `CallTool` で捕捉
+  2. ローカルで Available Tool List を収集（`TokenValidator`/`toolPermissions`/`serverStatusMap`/`projectId` でフィルタ）
+  3. クラウド Search API で検索（失敗時はローカル BM25 にフォールバック）
+  4. 選択結果を返却
+
+### MCP メタツール `tool_execute`
+- 設計背景: LLM や MCP クライアントによっては会話開始時のツールリストに固定されるため、動的にツールを実行できるよう固定メタツール経由でラップしている。
+- Input（CallTool `arguments`）:
+  ```ts
+  {
+    toolKey: string; // `${serverId}:${toolName}` など
+    arguments?: unknown;
+  }
+  ```
+- Output:
+  ```ts
+  {
+    result: unknown;
+  }
+  ```
+- 実装: `CallTool` で捕捉→`TokenValidator`/`toolPermissions`/`serverStatusMap`/`projectId` 検証→対象サーバへ `tools/call` を委譲。
+
+## 主要フロー
+
+### Search
+1. クライアントが MCP で `tool_discovery` を CallTool（`_meta.token/_meta.projectId` 付き）。
+2. `ToolCatalogService` が稼働サーバから Available Tool List を収集（`TokenValidator`、`toolPermissions`、`serverStatusMap`、`projectId` でフィルタ済み）。
+3. 検索プロバイダーに委譲:
+   - **クラウド検索（優先）**: `/catalog/search` に Query と Available Tool List を送信。
+   - **失敗時フォールバック**: ローカル BM25 検索で候補をスコアリング。
+4. 選択結果を MCP レスポンスとして返却。
+
+### Execute
+1. クライアント/LLM が MCP で `tool_execute` を CallTool（`_meta.token/_meta.projectId` 付き）。
+2. `TokenValidator`/`toolPermissions`/`serverStatusMap`/`projectId` を検証。
+3. 対象サーバへ `tools/call` を委譲し、結果を返却。
+
+## エラーハンドリングとセキュリティ
+- Token: `_meta.token` がない場合は検索/実行を拒否（要件によりオプションで許可）。401/403 は UI に表示。
+- Project: `_meta.projectId` が `UNASSIGNED_PROJECT_ID` または空の場合は null として扱い、フィルタ適用。
+- フォールバック: クラウド Search API は短め（例 5s）。エラー時はローカル BM25 にフォールバック。
+- ロギング: `requestId`, `serverId` を含めてローカルログに記録。
+
+## 段階的実装プラン
+
+### Phase 1: ローカル検索 ✅
+1. 型整備: `packages/shared` に `SearchRequest/SearchResponse` 型を追加。
+2. SearchProvider インターフェース: 検索アルゴリズムの抽象化。
+3. BM25SearchProvider: ローカル BM25 検索の実装。
+4. ToolCatalogService: 検索リクエスト時に Available Tool List を収集し、SearchProvider に委譲。
+5. MCP メタツール: `RequestHandlers` に `tool_discovery` / `tool_execute` を追加。
+
+### Phase 2: クラウド検索（後続）
+1. CloudSearchProvider: クラウド Search API クライアントを実装。
+2. フォールバック戦略: クラウド → BM25 のフォールバックロジックを ToolCatalogService に実装。
+3. 計測/テスト: クラウド検索の精度評価、フォールバック挙動のテスト。
+
+## 計測とテスト観点
+- スモーク: `tool_discovery` で検索できる、`tool_execute` で実行できる。
+- 負荷: 10+ サーバ時の検索応答時間を計測。
+- 信頼性: クラウド検索失敗時のフォールバック挙動を確認。
+- 回帰: `listResources/listPrompts` は従来通り、`listTools` は固定2ツールのみで動くことを確認。
+
+## リスク・未決事項
+- Search API スキーマの安定化とバージョン付け。後方互換をどう保つか。
+- 非稼働サーバの結果をどこまで表示するか（現状は除外想定）。
+- token 未指定時のポリシーを最終決定する必要がある。
+
+## アーキテクチャ図（Mermaid）
+```mermaid
+flowchart LR
+    subgraph Local["MCP Router (Local)"]
+        SM["MCPServerManager\n(listTools)"]
+        TCS["ToolCatalogService\n(collect tools + search)"]
+        BM25["BM25SearchProvider\n(fallback)"]
+        META["tool_discovery / tool_execute\n(RequestHandlers)"]
+    end
+
+    subgraph Cloud["Cloud (後続実装)"]
+        CS["Search API"]
+    end
+
+    META --> TCS
+    TCS --> SM
+    TCS -->|1. try| CS
+    TCS -->|2. fallback| BM25
+```

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,6 +10,7 @@ export * from "./user-types";
 export * from "./workspace";
 export * from "./auth";
 export * from "./project-types";
+export * from "./tool-catalog-types";
 
 // Re-export organized domain types
 export * from "./ui";

--- a/packages/shared/src/types/platform-api/domains/projects-api.ts
+++ b/packages/shared/src/types/platform-api/domains/projects-api.ts
@@ -1,8 +1,11 @@
-import type { Project } from "../../project-types";
+import type { Project, ProjectOptimization } from "../../project-types";
 
 export interface ProjectsAPI {
   list: () => Promise<Project[]>;
   create: (input: { name: string }) => Promise<Project>;
-  update: (id: string, updates: { name?: string }) => Promise<Project>;
+  update: (
+    id: string,
+    updates: { name?: string; optimization?: ProjectOptimization },
+  ) => Promise<Project>;
   delete: (id: string) => Promise<void>;
 }

--- a/packages/shared/src/types/project-types.ts
+++ b/packages/shared/src/types/project-types.ts
@@ -1,11 +1,16 @@
+export type ToolCatalogSearchStrategy = "bm25" | "cloud";
+export type ProjectOptimization = ToolCatalogSearchStrategy | null;
+
 export interface Project {
   id: string;
   name: string;
   createdAt: number;
   updatedAt: number;
+  optimization: ProjectOptimization;
 }
 
 // Shared constants for project handling
 // Use these across main, renderer, and CLI to avoid drift
 export const UNASSIGNED_PROJECT_ID = "__unassigned__" as const;
 export const PROJECT_HEADER = "x-mcpr-project" as const;
+export const DEFAULT_SEARCH_STRATEGY: ToolCatalogSearchStrategy = "bm25";

--- a/packages/shared/src/types/tool-catalog-types.ts
+++ b/packages/shared/src/types/tool-catalog-types.ts
@@ -1,0 +1,34 @@
+/**
+ * Tool information for search.
+ */
+export interface ToolInfo {
+  toolKey: string; // `${serverId}:${toolName}`
+  serverId: string;
+  toolName: string;
+  serverName: string;
+  projectId: string | null;
+  description?: string;
+  inputSchema?: {
+    properties?: Record<string, { description?: string }>;
+  };
+}
+
+export interface SearchRequest {
+  query: string[];
+  context?: string;
+  maxResults?: number;
+}
+
+export interface SearchResult {
+  toolName: string;
+  serverId: string;
+  serverName: string;
+  projectId: string | null;
+  description?: string;
+  relevance: number; // 0-1 normalized score
+  explanation?: string; // Optional explanation (e.g., selection reason)
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+}


### PR DESCRIPTION
## Summary
- BM25Fアルゴリズムによるツール検索機能を実装
- プロジェクト毎の最適化設定（context パラメータ）をサポート
- `tool_discovery` / `tool_execute` メタツールを提供

## Changes
1. **shared types**: tool-catalog と project-optimization の型定義を追加
2. **database**: projects テーブルに optimization カラムを追加
3. **tool-catalog**: BM25F search provider とカタログサービスを実装
4. **projects**: 最適化設定をプロジェクトモジュールに統合
5. **UI**: プロジェクト最適化設定UIを追加
6. **docs**: tool-catalog 設計とセキュリティドキュメントを追加

## Test plan
- [ ] プロジェクト設定モーダルで最適化設定が表示・保存されることを確認
- [ ] tool_discovery でツール検索ができることを確認
- [ ] tool_execute でツール実行ができることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)