### PR TITLE
feat(server-add): add project selection when adding servers

### DIFF
--- a/apps/electron/src/renderer/components/mcp/server/Manual.tsx
+++ b/apps/electron/src/renderer/components/mcp/server/Manual.tsx
@@ -748,6 +748,30 @@ const Manual: React.FC = () => {
               </div>
             </div>
 
+            <Row>
+              <Label>{t("serverSettings.project")}</Label>
+              <Select
+                value={selectedProjectId ?? "__none__"}
+                onValueChange={(v) =>
+                  setSelectedProjectId(v === "__none__" ? null : v)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("projects.unassigned")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">
+                    {t("projects.unassigned")}
+                  </SelectItem>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Row>
+
             <div className="flex items-center space-x-2">
               <Checkbox
                 id="auto-start-local"
@@ -888,6 +912,30 @@ const Manual: React.FC = () => {
                   </Label>
                 </div>
               </RadioGroup>
+            </Row>
+
+            <Row>
+              <Label>{t("serverSettings.project")}</Label>
+              <Select
+                value={selectedProjectId ?? "__none__"}
+                onValueChange={(v) =>
+                  setSelectedProjectId(v === "__none__" ? null : v)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("projects.unassigned")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">
+                    {t("projects.unassigned")}
+                  </SelectItem>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </Row>
 
             <div className="flex items-center space-x-2">

--- a/apps/electron/src/renderer/components/mcp/server/Manual.tsx
+++ b/apps/electron/src/renderer/components/mcp/server/Manual.tsx
@@ -29,7 +29,14 @@ import { MCPServerConfig } from "@mcp_router/shared";
 import { Checkbox } from "@mcp_router/ui";
 import { RadioGroup, RadioGroupItem } from "@mcp_router/ui";
 import { ScrollArea } from "@mcp_router/ui";
-import { useServerStore } from "@/renderer/stores";
+import { useServerStore, useProjectStore } from "@/renderer/stores";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcp_router/ui";
 
 interface EnvVariable {
   key: string;
@@ -62,6 +69,17 @@ const Manual: React.FC = () => {
   const { t } = useTranslation();
   const platformAPI = usePlatformAPI();
   const { createServer, refreshServers } = useServerStore();
+  const { projects, list: listProjects } = useProjectStore();
+
+  // Project Selection State (shared between Local and Remote tabs)
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+    null,
+  );
+
+  // Load projects on mount
+  React.useEffect(() => {
+    listProjects();
+  }, [listProjects]);
 
   // JSON Import State
   const [jsonInput, setJsonInput] = useState("");

--- a/apps/electron/src/renderer/components/mcp/server/Manual.tsx
+++ b/apps/electron/src/renderer/components/mcp/server/Manual.tsx
@@ -271,6 +271,7 @@ const Manual: React.FC = () => {
     setArgs("");
     setEnvVars([]);
     setValidationErrors({});
+    setSelectedProjectId(null);
   };
 
   const resetRemoteForm = () => {
@@ -280,6 +281,7 @@ const Manual: React.FC = () => {
     setRemoteValidationErrors({});
     setRemoteServerType("remote");
     setAutoStart(false);
+    setSelectedProjectId(null);
   };
 
   const handleDxtFileSelect = async (
@@ -357,6 +359,7 @@ const Manual: React.FC = () => {
         autoStart,
         disabled: false,
         serverType: "local",
+        projectId: selectedProjectId,
       };
       await createServer(serverConfig);
       toast.success(t("manual.successCreate", { name: serverName }));
@@ -383,6 +386,7 @@ const Manual: React.FC = () => {
         bearerToken,
         autoStart,
         disabled: false,
+        projectId: selectedProjectId,
       };
       await createServer(config);
       toast.success(


### PR DESCRIPTION
## Summary
- サーバー追加時にプロジェクトを選択できる機能を追加
- Local/Remote タブの両方でプロジェクト選択UIをサポート
- 選択されたprojectIdをサーバー作成時に含める

## Changes
1. **project store**: プロジェクト選択の状態管理を追加
2. **UI**: Local/Remote タブにプロジェクト選択ドロップダウンを追加
3. **server creation**: projectId をサーバー作成リクエストに含める

## Test plan
- [ ] Localタブでサーバー追加時にプロジェクトを選択できることを確認
- [ ] Remoteタブでサーバー追加時にプロジェクトを選択できることを確認
- [ ] 選択したプロジェクトにサーバーが正しく割り当てられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)