### PR TITLE
Fix Electron release packaging minimatch override

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "eslint>minimatch": "9.0.7",
       "fork-ts-checker-webpack-plugin>minimatch": "9.0.7",
       "micromatch>picomatch": "4.0.4",
-      "minimatch@<3.1.4": ">=3.1.4",
+      "minimatch@<3.1.4": "3.1.5",
       "minimatch@>=5.0.0 <5.1.8": ">=5.1.8",
       "minimatch@>=9.0.0 <9.0.7": ">=9.0.7",
       "minimatch@9.0.5": "9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   eslint>minimatch: 9.0.7
   fork-ts-checker-webpack-plugin>minimatch: 9.0.7
   micromatch>picomatch: 4.0.4
-  minimatch@<3.1.4: '>=3.1.4'
+  minimatch@<3.1.4: 3.1.5
   minimatch@>=5.0.0 <5.1.8: '>=5.1.8'
   minimatch@>=9.0.0 <9.0.7: '>=9.0.7'
   minimatch@9.0.5: 9.0.7
@@ -2913,9 +2913,6 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -4772,10 +4769,6 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.7:
     resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
@@ -7072,7 +7065,7 @@ snapshots:
     dependencies:
       commander: 5.1.0
       glob: 7.2.3
-      minimatch: 9.0.5
+      minimatch: 3.1.5
 
   '@electron/fuses@1.8.0':
     dependencies:
@@ -7343,7 +7336,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 9.0.7
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -7372,7 +7365,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 9.0.7
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -8789,7 +8782,7 @@ snapshots:
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
     optional: true
 
@@ -9444,10 +9437,6 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -10010,7 +9999,7 @@ snapshots:
 
   dir-compare@4.2.0:
     dependencies:
-      minimatch: 9.0.7
+      minimatch: 3.1.5
       p-limit: 3.1.0
 
   dlv@1.1.3: {}
@@ -10840,7 +10829,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 9.0.5
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -10849,7 +10838,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 9.0.5
+      minimatch: 10.2.5
       once: 1.4.0
 
   global-agent@3.0.0:
@@ -11483,10 +11472,6 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.1.1
 
   minimatch@9.0.7:
     dependencies:


### PR DESCRIPTION
## Summary
- Pin the minimatch override for legacy 3.x consumers to 3.1.5 instead of an open >= range.
- This keeps @electron/asar on a compatible CommonJS function export while preserving the security floor.

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm typecheck
- pnpm build
- git diff --check
- pnpm --filter @mcp_router/electron make reached the Electron download/package step locally; local network failed with ECONNRESET, while the previous CI failure was the minimatch compatibility error.