### PR TITLE
fix: pin xmldom for electron release build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "@hono/node-server@<1.19.14": ">=1.19.14",
       "@modelcontextprotocol/sdk@<1.29.0": ">=1.29.0",
       "@tootallnate/once@<2.0.1": ">=2.0.1",
-      "@xmldom/xmldom@<0.8.13": ">=0.8.13",
+      "@xmldom/xmldom@<0.8.13": "0.8.13",
       "@eslint/plugin-kit@<0.3.3": ">=0.3.3",
       "ajv@<7.0.0": "6.15.0",
       "ajv@>=7.0.0-alpha.0 <8.20.0": ">=8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   '@hono/node-server@<1.19.14': '>=1.19.14'
   '@modelcontextprotocol/sdk@<1.29.0': '>=1.29.0'
   '@tootallnate/once@<2.0.1': '>=2.0.1'
-  '@xmldom/xmldom@<0.8.13': '>=0.8.13'
+  '@xmldom/xmldom@<0.8.13': 0.8.13
   '@eslint/plugin-kit@<0.3.3': '>=0.3.3'
   ajv@<7.0.0: 6.15.0
   ajv@>=7.0.0-alpha.0 <8.20.0: '>=8.20.0'
@@ -2648,9 +2648,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9154,7 +9154,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -11925,7 +11925,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary
- pin the @xmldom/xmldom security override to 0.8.13 instead of allowing the incompatible 0.9.x line
- keep plist@3.1.0 compatible with Electron Packager's plist parsing during macOS make

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- git diff --check
- node -e "const plist=require('plist'); const x=require('./node_modules/@xmldom/xmldom/package.json'); const xml='<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict/></plist>'; console.log(x.version, JSON.stringify(plist.parse(xml)));"
- pnpm typecheck
- pnpm build
- pnpm --filter @mcp_router/electron make