### PR TITLE
fix: loosen MCP auth compatibility

### DIFF
--- a/apps/electron/src/main/modules/mcp-apps-manager/token-manager.ts
+++ b/apps/electron/src/main/modules/mcp-apps-manager/token-manager.ts
@@ -13,15 +13,6 @@ const DEFAULT_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
  * トークン管理機能を提供するクラス
  */
 export class TokenManager {
-  private getExpiresAt(token: Token): number {
-    return token.expiresAt ?? token.issuedAt + DEFAULT_TOKEN_TTL_SECONDS;
-  }
-
-  private isExpired(token: Token): boolean {
-    const now = Math.floor(Date.now() / 1000);
-    return !Number.isFinite(token.issuedAt) || this.getExpiresAt(token) <= now;
-  }
-
   /**
    * 新しいトークンを生成
    */
@@ -71,13 +62,6 @@ export class TokenManager {
       };
     }
 
-    if (this.isExpired(token)) {
-      return {
-        isValid: false,
-        error: "Token expired",
-      };
-    }
-
     return {
       isValid: true,
       clientId: token.clientId,
@@ -118,7 +102,7 @@ export class TokenManager {
    */
   public hasServerAccess(tokenId: string, serverId: string): boolean {
     const token = McpAppsManagerRepository.getInstance().getToken(tokenId);
-    if (!token || this.isExpired(token)) {
+    if (!token) {
       return false;
     }
     return !!token.serverAccess?.[serverId];

--- a/apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts
+++ b/apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts
@@ -9,9 +9,9 @@ import { TokenValidator } from "../token-validator";
 import { ProjectRepository } from "../../projects/projects.repository";
 import { PROJECT_HEADER, UNASSIGNED_PROJECT_ID } from "@mcp_router/shared";
 
-const MAX_AUTHORIZATION_HEADER_LENGTH = 512;
+const MAX_AUTHORIZATION_HEADER_LENGTH = 4096;
 const MAX_PROJECT_HEADER_LENGTH = 128;
-const BEARER_TOKEN_PATTERN = /^Bearer ([A-Za-z0-9._~+/-]+=*)$/;
+const BEARER_TOKEN_PREFIX_PATTERN = /^Bearer\s+/i;
 const DEFAULT_HTTP_HOST = "127.0.0.1";
 
 function hasHttpHeaderControlChars(value: string): boolean {
@@ -121,12 +121,23 @@ export class MCPHttpServer {
       return null;
     }
 
-    const match = BEARER_TOKEN_PATTERN.exec(headerValue);
-    if (!match) {
+    let token = headerValue.trim();
+    while (BEARER_TOKEN_PREFIX_PATTERN.test(token)) {
+      token = token.replace(BEARER_TOKEN_PREFIX_PATTERN, "").trim();
+    }
+
+    if (
+      (token.startsWith('"') && token.endsWith('"')) ||
+      (token.startsWith("'") && token.endsWith("'"))
+    ) {
+      token = token.slice(1, -1).trim();
+    }
+
+    if (!token) {
       return null;
     }
 
-    return match[1];
+    return token;
   }
 
   private getSingleHeaderValue(

--- a/apps/electron/tests/mcp-http-server-auth.test.cjs
+++ b/apps/electron/tests/mcp-http-server-auth.test.cjs
@@ -1,0 +1,79 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const path = require("node:path");
+const os = require("node:os");
+
+process.env.TS_NODE_PROJECT = path.join(__dirname, "../tsconfig.json");
+
+const originalLoad = Module._load;
+Module._load = function loadWithRuntimeStubs(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: {
+        getPath: () => path.join(os.tmpdir(), "mcp-router-http-test"),
+      },
+    };
+  }
+  if (request === "@mcp_router/shared") {
+    return {
+      PROJECT_HEADER: "x-mcpr-project",
+      UNASSIGNED_PROJECT_ID: "__unassigned__",
+    };
+  }
+  if (request === "@modelcontextprotocol/sdk/server/sse") {
+    return { SSEServerTransport: class SSEServerTransport {} };
+  }
+  if (request === "../../mcp-server-manager/mcp-server-manager") {
+    return { MCPServerManager: class MCPServerManager {} };
+  }
+  if (request === "../aggregator-server") {
+    return { AggregatorServer: class AggregatorServer {} };
+  }
+  if (request === "../../workspace/platform-api-manager") {
+    return {
+      getPlatformAPIManager: () => ({ isRemoteWorkspace: () => false }),
+    };
+  }
+  if (request === "../token-validator") {
+    return { TokenValidator: class TokenValidator {} };
+  }
+  if (request === "../../projects/projects.repository") {
+    return {
+      ProjectRepository: {
+        getInstance: () => ({ findByName: () => null }),
+      },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+require("ts-node/register/transpile-only");
+
+const {
+  MCPHttpServer,
+} = require("../src/main/modules/mcp-server-runtime/http/mcp-http-server.ts");
+
+const extractBearerToken = (value) =>
+  MCPHttpServer.prototype.extractBearerToken.call({}, value);
+
+describe("MCPHttpServer Authorization compatibility", () => {
+  it("accepts legacy raw token headers", () => {
+    assert.equal(extractBearerToken("mcpr_legacy"), "mcpr_legacy");
+  });
+
+  it("accepts Bearer headers with casing, spacing, and quoted token variations", () => {
+    assert.equal(extractBearerToken("bearer mcpr_lower"), "mcpr_lower");
+    assert.equal(extractBearerToken("Bearer   mcpr_spaced"), "mcpr_spaced");
+    assert.equal(extractBearerToken("Bearer Bearer mcpr_nested"), "mcpr_nested");
+    assert.equal(extractBearerToken('Bearer "mcpr_quoted"'), "mcpr_quoted");
+  });
+
+  it("rejects ambiguous or unsafe Authorization headers", () => {
+    assert.equal(extractBearerToken(["Bearer mcpr_one", "Bearer mcpr_two"]), null);
+    assert.equal(extractBearerToken("Bearer mcpr_bad\nnext"), null);
+    assert.equal(extractBearerToken(""), null);
+  });
+});
+
+Module._load = originalLoad;

--- a/apps/electron/tests/token-manager.test.cjs
+++ b/apps/electron/tests/token-manager.test.cjs
@@ -1,0 +1,120 @@
+const { describe, it, beforeEach, after } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const path = require("node:path");
+const os = require("node:os");
+
+process.env.TS_NODE_PROJECT = path.join(__dirname, "../tsconfig.json");
+
+const originalLoad = Module._load;
+Module._load = function loadWithElectronStub(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: {
+        getPath: () => path.join(os.tmpdir(), "mcp-router-token-test"),
+      },
+    };
+  }
+  if (request === "@mcp_router/shared") {
+    return {};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+require("ts-node/register/transpile-only");
+
+const {
+  McpAppsManagerRepository,
+} = require("../src/main/modules/mcp-apps-manager/mcp-apps-manager.repository.ts");
+const {
+  TokenManager,
+} = require("../src/main/modules/mcp-apps-manager/token-manager.ts");
+
+describe("TokenManager", () => {
+  let tokens;
+
+  beforeEach(() => {
+    tokens = new Map();
+    McpAppsManagerRepository.getInstance = () => ({
+      getToken: (id) => tokens.get(id) || null,
+      getTokensByClientId: (clientId) =>
+        Array.from(tokens.values()).filter(
+          (token) => token.clientId === clientId,
+        ),
+      deleteClientTokens: (clientId) => {
+        let count = 0;
+        for (const [id, token] of tokens.entries()) {
+          if (token.clientId === clientId) {
+            tokens.delete(id);
+            count += 1;
+          }
+        }
+        return count;
+      },
+      saveToken: (token) => {
+        tokens.set(token.id, token);
+      },
+      deleteToken: (id) => tokens.delete(id),
+      listTokens: () => Array.from(tokens.values()),
+      updateTokenServerAccess: (id, serverAccess) => {
+        const token = tokens.get(id);
+        if (!token) return false;
+        token.serverAccess = serverAccess || {};
+        return true;
+      },
+    });
+  });
+
+  after(() => {
+    Module._load = originalLoad;
+  });
+
+  it("keeps legacy tokens without expiresAt valid after the TTL feature is introduced", () => {
+    const issuedAtMoreThanThirtyDaysAgo =
+      Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
+    tokens.set("mcpr_legacy", {
+      id: "mcpr_legacy",
+      clientId: "codex",
+      issuedAt: issuedAtMoreThanThirtyDaysAgo,
+      serverAccess: {},
+    });
+
+    const validation = new TokenManager().validateToken("mcpr_legacy");
+
+    assert.deepEqual(validation, {
+      isValid: true,
+      clientId: "codex",
+    });
+  });
+
+  it("keeps tokens with expired expiresAt valid for MCP compatibility", () => {
+    tokens.set("mcpr_expired", {
+      id: "mcpr_expired",
+      clientId: "codex",
+      issuedAt: Math.floor(Date.now() / 1000) - 60,
+      expiresAt: Math.floor(Date.now() / 1000) - 1,
+      serverAccess: {},
+    });
+
+    const validation = new TokenManager().validateToken("mcpr_expired");
+
+    assert.deepEqual(validation, {
+      isValid: true,
+      clientId: "codex",
+    });
+  });
+
+  it("sets expiresAt on newly generated tokens", () => {
+    const before = Math.floor(Date.now() / 1000);
+
+    const token = new TokenManager().generateToken({
+      clientId: "codex",
+      serverAccess: {},
+    });
+
+    assert.equal(token.clientId, "codex");
+    assert.match(token.id, /^mcpr_[A-Za-z0-9_-]+$/);
+    assert.equal(typeof token.expiresAt, "number");
+    assert.ok(token.expiresAt >= before + 30 * 24 * 60 * 60);
+  });
+});

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,9 +7,9 @@
 - CLI HTTP サーバーは既定で `127.0.0.1` のみに bind し、外部公開する場合は `--token` を必須化。
 - Remote MCP URL は `https`、FQDN、DNS 解決結果、リダイレクト先を検証し、localhost/private/reserved IP への接続を拒否。
 - MCP サーバー bearer token とデスクトップ認証 token は Electron `safeStorage` が利用可能な環境で暗号化保存。
-- 共有 token に 30 日の有効期限を付与し、期限切れ token と malformed token を拒否。
+- 共有 token に `expiresAt` を保存しつつ、既存 MCP クライアント互換性のため認証・server access では期限切れ拒否しない。無効化は明示的な revoke / 再生成で行う。
 - 新規サーバー追加や sync 時に、既存 token へサーバーアクセスを自動付与しない。
-- HTTP authorization/project headers は単一値・長さ・制御文字を検証してから使用。
+- HTTP authorization/project headers は単一値・長さ・制御文字を検証してから使用。Authorization は raw token と `Bearer <token>` の表記揺れを受け付ける。
 - Skill ディレクトリ操作は保存ディレクトリ内に閉じ、インポート時の symlink を拒否。
 - Workflow は循環グラフを保存/有効化前に拒否し、Hook context と実行結果から token/API key/password 系の値を redaction。
 


### PR DESCRIPTION
## Summary
- keep existing MCP Router app tokens valid even when they have no or expired expiresAt metadata
- accept common Authorization header variations such as raw tokens, lower-case bearer, extra spacing, nested Bearer, and quoted tokens
- document the compatibility-first token policy and add regression tests

## Root cause
Recent stricter token expiry and Authorization parsing could reject existing Codex/MCP Router configurations during MCP initialization, surfacing as Streamable HTTP POST failures before tools could load.

## Validation
- node --test apps/electron/tests/token-manager.test.cjs
- node --test apps/electron/tests/mcp-http-server-auth.test.cjs
- pnpm typecheck