### PR TITLE
fix(electron): isolate stateless MCP requests

### DIFF
--- a/apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts
+++ b/apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts
@@ -1,5 +1,5 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
@@ -13,6 +13,7 @@ import { RequestHandlers } from "./request-handlers";
 import { MCPServerManager } from "../mcp-server-manager/mcp-server-manager";
 import { getLogService } from "@/main/modules/mcp-logger/mcp-logger.service";
 import type { ToolCatalogService } from "@/main/modules/tool-catalog/tool-catalog.service";
+import type { Request, Response } from "express";
 
 /**
  * MCP Aggregator Server that combines multiple MCP servers into one
@@ -38,44 +39,46 @@ export class AggregatorServer {
    */
   private async initAggregatorServer(): Promise<void> {
     try {
-      // Initialize the MCP server
-      this.aggregatorServer = new Server(
-        {
-          name: "mcp-aggregator",
-          version: "1.0.0",
-        },
-        {
-          capabilities: {
-            resources: {},
-            tools: {},
-            prompts: {},
-          },
-        },
-      );
-
-      // Set up request handlers
-      this.setupRequestHandlers();
-
-      // Error handling
-      this.aggregatorServer.onerror = (error) => {
-        console.error("[MCP Aggregator Error]", error);
-        // Log server errors
-        getLogService().recordMcpRequestLog({
-          timestamp: new Date().toISOString(),
-          requestType: "ServerError",
-          params: {},
-          result: "error",
-          errorMessage: error.message || "Unknown server error",
-          duration: 0,
-          clientId: "mcp-router-system",
-        });
-      };
+      this.aggregatorServer = this.createAggregatorServer();
 
       // Start the aggregator server
       await this.startAggregator();
     } catch (error) {
       console.error("Failed to initialize MCP Aggregator Server:", error);
     }
+  }
+
+  private createAggregatorServer(): Server {
+    const server = new Server(
+      {
+        name: "mcp-aggregator",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          resources: {},
+          tools: {},
+          prompts: {},
+        },
+      },
+    );
+
+    this.setupRequestHandlers(server);
+
+    server.onerror = (error) => {
+      console.error("[MCP Aggregator Error]", error);
+      getLogService().recordMcpRequestLog({
+        timestamp: new Date().toISOString(),
+        requestType: "ServerError",
+        params: {},
+        result: "error",
+        errorMessage: error.message || "Unknown server error",
+        duration: 0,
+        clientId: "mcp-router-system",
+      });
+    };
+
+    return server;
   }
 
   /**
@@ -90,6 +93,24 @@ export class AggregatorServer {
    */
   public getAggregatorServer(): Server {
     return this.aggregatorServer;
+  }
+
+  public async handleRequest(
+    req: Request,
+    res: Response,
+    body: unknown,
+  ): Promise<void> {
+    const server = this.createAggregatorServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } finally {
+      await server.close();
+    }
   }
 
   /**
@@ -114,37 +135,28 @@ export class AggregatorServer {
   /**
    * Set up request handlers for the aggregator server
    */
-  private setupRequestHandlers(): void {
+  private setupRequestHandlers(server: Server): void {
     // List Tools
-    this.aggregatorServer.setRequestHandler(
-      ListToolsRequestSchema,
-      async (request) => {
-        const token = request.params?._meta?.token as string | undefined;
-        const projectId = request.params?._meta?.projectId;
-        return await this.requestHandlers.handleListTools(token, projectId);
-      },
-    );
+    server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+      const token = request.params?._meta?.token as string | undefined;
+      const projectId = request.params?._meta?.projectId;
+      return await this.requestHandlers.handleListTools(token, projectId);
+    });
 
     // Call Tool
-    this.aggregatorServer.setRequestHandler(
-      CallToolRequestSchema,
-      async (request) => {
-        return await this.requestHandlers.handleCallTool(request);
-      },
-    );
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      return await this.requestHandlers.handleCallTool(request);
+    });
 
     // List Resources
-    this.aggregatorServer.setRequestHandler(
-      ListResourcesRequestSchema,
-      async (request) => {
-        const token = request.params?._meta?.token as string | undefined;
-        const projectId = request.params?._meta?.projectId;
-        return await this.requestHandlers.handleListResources(token, projectId);
-      },
-    );
+    server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
+      const token = request.params?._meta?.token as string | undefined;
+      const projectId = request.params?._meta?.projectId;
+      return await this.requestHandlers.handleListResources(token, projectId);
+    });
 
     // List Resource Templates
-    this.aggregatorServer.setRequestHandler(
+    server.setRequestHandler(
       ListResourceTemplatesRequestSchema,
       async (request) => {
         const token = request.params?._meta?.token as string | undefined;
@@ -157,49 +169,40 @@ export class AggregatorServer {
     );
 
     // Read Resource
-    this.aggregatorServer.setRequestHandler(
-      ReadResourceRequestSchema,
-      async (request) => {
-        const uri = request.params.uri;
-        const token = request.params?._meta?.token as string | undefined;
-        const projectId = request.params?._meta?.projectId;
-        return await this.requestHandlers.readResourceByUri(
-          uri,
-          token,
-          projectId,
-        );
-      },
-    );
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const uri = request.params.uri;
+      const token = request.params?._meta?.token as string | undefined;
+      const projectId = request.params?._meta?.projectId;
+      return await this.requestHandlers.readResourceByUri(
+        uri,
+        token,
+        projectId,
+      );
+    });
 
     // List Prompts
-    this.aggregatorServer.setRequestHandler(
-      ListPromptsRequestSchema,
-      async (request) => {
-        const token = request.params?._meta?.token as string | undefined;
-        const projectId = request.params?._meta?.projectId;
-        const allPrompts = await this.requestHandlers.getAllPromptsInternal(
-          token,
-          projectId,
-        );
-        return { prompts: allPrompts };
-      },
-    );
+    server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+      const token = request.params?._meta?.token as string | undefined;
+      const projectId = request.params?._meta?.projectId;
+      const allPrompts = await this.requestHandlers.getAllPromptsInternal(
+        token,
+        projectId,
+      );
+      return { prompts: allPrompts };
+    });
 
     // Get Prompt
-    this.aggregatorServer.setRequestHandler(
-      GetPromptRequestSchema,
-      async (request) => {
-        const promptName = request.params.name;
-        const token = request.params?._meta?.token as string | undefined;
-        const projectId = request.params?._meta?.projectId;
-        return await this.requestHandlers.getPromptByName(
-          promptName,
-          request.params.arguments,
-          token,
-          projectId,
-        );
-      },
-    );
+    server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const promptName = request.params.name;
+      const token = request.params?._meta?.token as string | undefined;
+      const projectId = request.params?._meta?.projectId;
+      return await this.requestHandlers.getPromptByName(
+        promptName,
+        request.params.arguments,
+        token,
+        projectId,
+      );
+    });
   }
 
   /**

--- a/apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts
+++ b/apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts
@@ -286,9 +286,7 @@ export class MCPHttpServer {
         const token = req.headers["authorization"];
         this.attachRequestMetadata(modifiedBody, token, projectFilter);
         // For local workspaces, use local aggregator
-        await this.aggregatorServer
-          .getTransport()
-          .handleRequest(req, res, modifiedBody);
+        await this.aggregatorServer.handleRequest(req, res, modifiedBody);
       } catch (error) {
         console.error("Error handling MCP request:", error);
         if (!res.headersSent) {

--- a/apps/electron/tests/mcp-http-server-stateless.test.cjs
+++ b/apps/electron/tests/mcp-http-server-stateless.test.cjs
@@ -1,0 +1,122 @@
+const { after, before, describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const path = require("node:path");
+const os = require("node:os");
+
+process.env.TS_NODE_PROJECT = path.join(__dirname, "../tsconfig.json");
+
+const originalLoad = Module._load;
+Module._load = function loadWithRuntimeStubs(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: { getPath: () => path.join(os.tmpdir(), "mcp-router-http-test") },
+    };
+  }
+  if (request === "@mcp_router/shared") {
+    return {
+      PROJECT_HEADER: "x-mcpr-project",
+      UNASSIGNED_PROJECT_ID: "__unassigned__",
+    };
+  }
+  if (request === "./request-handlers") {
+    return {
+      RequestHandlers: class RequestHandlers {
+        async handleListTools() {
+          return { tools: [] };
+        }
+      },
+    };
+  }
+  if (request === "@/main/modules/mcp-logger/mcp-logger.service") {
+    return { getLogService: () => ({ recordMcpRequestLog() {} }) };
+  }
+  if (request === "@modelcontextprotocol/sdk/server/sse") {
+    return { SSEServerTransport: class SSEServerTransport {} };
+  }
+  if (request === "../../workspace/platform-api-manager") {
+    return {
+      getPlatformAPIManager: () => ({ isRemoteWorkspace: () => false }),
+    };
+  }
+  if (request === "../token-validator") {
+    return {
+      TokenValidator: class TokenValidator {
+        validateToken() {
+          return { isValid: true };
+        }
+      },
+    };
+  }
+  if (request === "../../projects/projects.repository") {
+    return {
+      ProjectRepository: { getInstance: () => ({ findByName: () => null }) },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+require("ts-node/register/transpile-only");
+
+const {
+  AggregatorServer,
+} = require("../src/main/modules/mcp-server-runtime/aggregator-server.ts");
+const {
+  MCPHttpServer,
+} = require("../src/main/modules/mcp-server-runtime/http/mcp-http-server.ts");
+
+describe("MCPHttpServer stateless MCP sequence", () => {
+  let aggregator;
+  let listener;
+  let endpoint;
+
+  before(async () => {
+    aggregator = new AggregatorServer({});
+    const server = new MCPHttpServer({}, 0, aggregator);
+    listener = server.app.listen(0, "127.0.0.1");
+    await new Promise((resolve) => listener.once("listening", resolve));
+    endpoint = `http://127.0.0.1:${listener.address().port}/mcp`;
+  });
+
+  after(async () => {
+    await new Promise((resolve, reject) =>
+      listener.close((error) => (error ? reject(error) : resolve())),
+    );
+    await aggregator.shutdown();
+    Module._load = originalLoad;
+  });
+
+  it("handles initialize followed by notifications/initialized", async () => {
+    const headers = {
+      accept: "application/json, text/event-stream",
+      authorization: "mcpr_test",
+      "content-type": "application/json",
+    };
+    const initialize = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      }),
+    });
+    assert.equal(initialize.status, 200);
+
+    const initialized = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      }),
+    });
+    assert.equal(initialized.status, 202);
+  });
+});


### PR DESCRIPTION
## Summary

The Electron `/mcp` endpoint reuses one stateless `StreamableHTTPServerTransport` across requests. SDK 1.29 consumes a stateless transport after its first request, so a normal `initialize` followed by `notifications/initialized` fails on the second POST.

This change gives each Electron `/mcp` request its own configured MCP `Server` and stateless transport, while preserving the existing shared request handlers and legacy SSE server path.

## Related issues

Closes #195.

## Changes

- Extract MCP server construction so every request receives the same tools, resources, prompts, logging, and request-handler configuration.
- Create and connect one stateless transport and MCP server per `/mcp` request.
- Close the request-scoped server after request handling completes.
- Add a route-level regression using the real MCP SDK sequence: `initialize` returns HTTP 200 and `notifications/initialized` returns HTTP 202.

## Screenshots / Videos (if UI changes)

Not applicable; this changes the Electron main-process MCP request lifecycle only.

## Verification

```bash
pnpm exec node --test apps/electron/tests/*.test.cjs
pnpm --filter @mcp_router/shared build
pnpm --filter @mcp_router/ui build
pnpm --filter @mcp_router/remote-api-types build
pnpm --filter @mcp_router/electron typecheck
pnpm exec eslint apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts apps/electron/tests/mcp-http-server-stateless.test.cjs
pnpm exec prettier --check apps/electron/src/main/modules/mcp-server-runtime/aggregator-server.ts apps/electron/src/main/modules/mcp-server-runtime/http/mcp-http-server.ts apps/electron/tests/mcp-http-server-stateless.test.cjs
```

The focused ESLint run reports the seven existing `no-explicit-any` warnings in `mcp-http-server.ts` and no errors.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] Tests added/updated if needed
- [x] Documentation updated (README, comments, etc.) if needed
- [x] I will sign the CLA
